### PR TITLE
Revise the definition of Posix related macro at R_BSP dir to pass IAR compiler using the latest Mbed OS.

### DIFF
--- a/R_BSP/RenesasBSP/drv_inc/posix_types.h
+++ b/R_BSP/RenesasBSP/drv_inc/posix_types.h
@@ -51,10 +51,6 @@
 extern "C" {
 #endif
 
-#if(1) /* mbed */
-#include "mbed_retarget.h"
-#endif
-
 /* From <unistd.h> */
 #ifndef SEEK_SET
 #define SEEK_SET        0           /* from the biginning of file */
@@ -81,6 +77,10 @@ extern "C" {
  * otherwise the buffered file functions fopen() etc. will not work.
  */
 #if(1) /* mbed */
+#define O_ACCMODE_RBSP  00000007
+#define O_RDONLY_RBSP   00000001
+#define O_WRONLY_RBSP   00000002
+#define O_RDWR_RBSP     00000004
 #else  /* not mbed */
 #define O_ACCMODE       00000007
 #define O_RDONLY        00000001

--- a/R_BSP/RenesasBSP/drv_inc/r_errno.h
+++ b/R_BSP/RenesasBSP/drv_inc/r_errno.h
@@ -8,11 +8,6 @@
  * (C) Copyright RENESAS ELECTRONICS Ltd 2012 All Rights Reserved
  *****************************************************************************/
 
-/* Detect if SHC include errno.h has been included first, this is not supported */
-#ifdef _ERRNO
-    #error Renesas/Sh/9_x_x/include/errno.h has been included before SDK errno.h. Please specify SDK include path first.
-#endif
-
 #ifndef SDK_ERRNO
 #define SDK_ERRNO
 
@@ -32,18 +27,26 @@ extern "C" {
 /***********************************************************************************
  System Includes
 ***********************************************************************************/
-#ifdef EBADF
-    #undef EBADF
-#endif
-#ifdef EDOM
-    #undef EDOM
-#endif
-
 /* SDK errno extension, SDK returns 0 as success, and -1 when errno set */
 #define ESUCCESS    (0)
 #define EERROR      (-1)
 
-#if(0)
+#if(1) /* mbed */
+#define EBADF_RBSP       (-17) /* Bad file descriptor */
+#define EINVAL_RBSP      (-28) /* Invalid argument */
+#define ENOMEM_RBSP      (-33) /* No memory available */
+#define ENOENT_RBSP      (-42) /* No such file or directory */
+#define EACCES_RBSP      (-64) /* Access denied */
+#define EBUSY_RBSP       (-67) /* Device or resource busy */
+#define ECANCELED_RBSP   (-68) /* Operation was cancelled */
+#define EIO_RBSP         (-74) /* Input or Output error (possibly recoverable)*/
+#define EMFILE_RBSP      (-76) /* Too many open files */
+#define ENOSPC_RBSP      (-84) /* No space available on device */
+#define ENOTSUP_RBSP     (-87) /* Not supported */
+#define EPERM_RBSP       (-90) /* Operation not permitted */
+#define EFAULT_RBSP      (-97) /* Section fault, bad address */
+#define EOVERFLOW_RBSP  (-117) /* Value too large to store in data type */
+#else  /* not mbed */
 #define EBADF       (-17) /* Bad file descriptor */
 #define EINVAL      (-28) /* Invalid argument */
 #define ENOMEM      (-33) /* No memory available */
@@ -108,11 +111,7 @@ extern "C" {
 #define EMEDIUMTYPE (-127) /* Wrong medium type */
 #define ENOMEDIUM   (-128) /* No medium present */
 #define ESEEKRANGE  (-129) /* seek setting error */  /* Source Merge 11-1 */
-#endif
-#define EBADF       (201) /* Bad file descriptor */
-#ifndef ENOTSUP
-#define ENOTSUP     (202) /* Not supported */
-#endif
+#endif /* end mbed */
 
 /***********************************************************************************
  Defines

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/dma/dma.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/dma/dma.c
@@ -509,13 +509,13 @@ End of function DMA_OpenChannel
 * Return Value :   channel -
 *                     Open channel number.
 *                  error code -
-*                     EMFILE : When looking for a free channel, but a free
+*                     EMFILE_RBSP : When looking for a free channel, but a free
 *                              channel didn't exist.
 ******************************************************************************/
 
 int_t DMA_GetFreeChannel(void)
 {
-    int_t           retval = EFAULT;
+    int_t           retval = EFAULT_RBSP;
     dma_info_ch_t   *dma_info_ch;
     int_t           ch_alloc;
     bool_t          ch_stat_check_flag;
@@ -542,7 +542,7 @@ int_t DMA_GetFreeChannel(void)
                 if (DMA_CH_NUM == ch_alloc)
                 {
                     /* set error return value */
-                    retval = EMFILE;
+                    retval = EMFILE_RBSP;
                     ch_stat_check_flag = true;
                 }
             }
@@ -1005,7 +1005,7 @@ End of function DMA_SetErrCode
 *               Notify error information to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB member.
+*                Note: store error code (EIO_RBSP) to AIOCB member.
 ******************************************************************************/
 
 static void R_DMA_ErrInterruptHandler(void)
@@ -1022,8 +1022,8 @@ static void R_DMA_ErrInterruptHandler(void)
         /* set error infrmation */
         gb_info_drv.p_err_aio->aio_sigevent.sigev_value.sival_int = (int_t)(dstat_er_0_7 | (dstat_er_8_15 << HIGH_COMMON_REG_OFFSET));
 
-        /* set error code (EIO) */
-        gb_info_drv.p_err_aio->aio_return = EIO;
+        /* set error code (EIO_RBSP) */
+        gb_info_drv.p_err_aio->aio_return = EIO_RBSP;
 
         /* call back to the module function which called DMA driver */
         ahf_complete(NULL, gb_info_drv.p_err_aio);
@@ -1047,10 +1047,10 @@ End of function R_DMA_ErrInteruuptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1072,10 +1072,10 @@ End of function R_DMA_End0InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1097,10 +1097,10 @@ End of function R_DMA_End1InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1122,10 +1122,10 @@ End of function R_DMA_End2InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1147,10 +1147,10 @@ End of function R_DMA_End3InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1172,10 +1172,10 @@ End of function R_DMA_End4InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1197,10 +1197,10 @@ End of function R_DMA_End5InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1222,10 +1222,10 @@ End of function R_DMA_End6InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1247,10 +1247,10 @@ End of function R_DMA_End7InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1272,10 +1272,10 @@ End of function R_DMA_End8InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1297,10 +1297,10 @@ End of function R_DMA_End9InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1322,10 +1322,10 @@ End of function R_DMA_End10InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1347,10 +1347,10 @@ End of function R_DMA_End11InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1372,10 +1372,10 @@ End of function R_DMA_End12InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1397,10 +1397,10 @@ End of function R_DMA_End13InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1422,10 +1422,10 @@ End of function R_DMA_End14InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1448,10 +1448,10 @@ End of function R_DMA_End15InterruptHandler
 * Arguments : channel -
 *                  Open channel number.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1493,8 +1493,8 @@ __INLINE static void R_DMA_EndHandlerProcess(const int_t channel)
             }
             else
             {
-                /* set error code (EIO) */
-                gb_info_drv.info_ch[channel].p_end_aio->aio_return = EIO;
+                /* set error code (EIO_RBSP) */
+                gb_info_drv.info_ch[channel].p_end_aio->aio_return = EIO_RBSP;
             }
         }
         else

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/dma/dma_if.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/dma/dma_if.c
@@ -56,9 +56,9 @@ Private global tables
 *                                  When pointer is NULL, it isn't set error code.
 *                                  error code -
 *                                  OS error num : Registering handler failed.
-*                                  EPERM : Pointer of callback function which called in DMA 
+*                                  EPERM_RBSP : Pointer of callback function which called in DMA 
 *                                          error interrupt handler is NULL.
-*                                  EFAULT : dma_init_param is NULL.
+*                                  EFAULT_RBSP : dma_init_param is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -78,7 +78,7 @@ int_t R_DMA_Init(const dma_drv_init_t * const p_dma_init_param, int32_t * const 
     {
         /* set error return value */
         retval = (EERROR);
-        DMA_SetErrCode(EFAULT, p_errno);
+        DMA_SetErrCode(EFAULT_RBSP, p_errno);
     }
 
     if (ESUCCESS == retval)
@@ -89,7 +89,7 @@ int_t R_DMA_Init(const dma_drv_init_t * const p_dma_init_param, int32_t * const 
         {
             /* set error return value */
             retval = (EERROR);
-            DMA_SetErrCode(EPERM, p_errno);
+            DMA_SetErrCode(EPERM_RBSP, p_errno);
         }
     }
 
@@ -127,9 +127,9 @@ End of function R_DMA_Init
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
 *                           OS error num : Unegistering handler failed.
-*                           EACCES : Driver status isn't DMA_DRV_INIT.
-*                           EBUSY : It has been allocated already in channel.
-*                           EFAULT : Channel status is besides the status definded in dma_stat_ch_t.
+*                           EACCES_RBSP : Driver status isn't DMA_DRV_INIT.
+*                           EBUSY_RBSP : It has been allocated already in channel.
+*                           EFAULT_RBSP : Channel status is besides the status definded in dma_stat_ch_t.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -161,7 +161,7 @@ int_t R_DMA_UnInit(int32_t * const p_errno)
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EACCES, p_errno);
+            DMA_SetErrCode(EACCES_RBSP, p_errno);
         }
         else
         {
@@ -182,11 +182,11 @@ int_t R_DMA_UnInit(int32_t * const p_errno)
                         /* These 2 cases are intentionally combined. */
                         case DMA_CH_OPEN:
                         case DMA_CH_TRANSFER:
-                            DMA_SetErrCode(EBUSY, p_errno);
+                            DMA_SetErrCode(EBUSY_RBSP, p_errno);
                         break;
 
                         default:
-                            DMA_SetErrCode(EFAULT, p_errno);
+                            DMA_SetErrCode(EFAULT_RBSP, p_errno);
                         break;
                     }
                 }
@@ -233,12 +233,12 @@ End of function R_DMA_UnInit
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EINVAL : Value of the ch is outside the range of DMA_ALLOC_CH(-1) <= ch < DMA_CH_NUM.
-*                           EACCES : Driver status isn't DMA_DRV_INIT.
-*                           EBUSY : It has been allocated already in channel.
-*                           EMFILE : When looking for a free channel, but a free channel didn't exist.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t.
+*                           EINVAL_RBSP : Value of the ch is outside the range of DMA_ALLOC_CH(-1) <= ch < DMA_CH_NUM.
+*                           EACCES_RBSP : Driver status isn't DMA_DRV_INIT.
+*                           EBUSY_RBSP : It has been allocated already in channel.
+*                           EMFILE_RBSP : When looking for a free channel, but a free channel didn't exist.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -267,7 +267,7 @@ int_t R_DMA_Alloc(const int_t channel, int32_t * const p_errno)
         if (DMA_DRV_INIT != dma_info_drv->drv_stat)
         {
             /* set error return value */
-            ercd =  EACCES;
+            ercd =  EACCES_RBSP;
         }
         else
         {
@@ -298,7 +298,7 @@ int_t R_DMA_Alloc(const int_t channel, int32_t * const p_errno)
             else
             {
                 /* set error return value */
-                ercd =  EINVAL;
+                ercd =  EINVAL_RBSP;
             }
         }
     }
@@ -330,12 +330,12 @@ End of function R_DMA_Alloc
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EACCES : Driver status isn't DMA_DRV_INIT.
-*                           EBUSY : It has been start DMA transfer in channel.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EACCES_RBSP : Driver status isn't DMA_DRV_INIT.
+*                           EBUSY_RBSP : It has been start DMA transfer in channel.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -382,19 +382,19 @@ int_t R_DMA_Free(const int_t channel, int32_t *const p_errno)
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                             break;
 
                             case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                             break;
 
                             case DMA_CH_TRANSFER:
-                                error_code = EBUSY;
+                                error_code = EBUSY_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                             break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -405,7 +405,7 @@ int_t R_DMA_Free(const int_t channel, int32_t *const p_errno)
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EACCES, p_errno);
+                DMA_SetErrCode(EACCES_RBSP, p_errno);
 
             }
         }
@@ -414,7 +414,7 @@ int_t R_DMA_Free(const int_t channel, int32_t *const p_errno)
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();
@@ -438,12 +438,12 @@ End of function R_DMA_Free
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EBUSY : It has been start DMA transfer in channel.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EPERM : The value in p_ch_setup isn't in the right range.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_ch_setup is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EBUSY_RBSP : It has been start DMA transfer in channel.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EPERM_RBSP : The value in p_ch_setup isn't in the right range.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_ch_setup is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -593,7 +593,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EPERM, p_errno);
+                DMA_SetErrCode(EPERM_RBSP, p_errno);
             }
 
             if (ESUCCESS == retval)
@@ -604,7 +604,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -616,7 +616,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -628,7 +628,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -640,7 +640,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -652,7 +652,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -694,7 +694,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                         {
                             /* set error return value */
                             retval = EERROR;
-                            DMA_SetErrCode(EPERM, p_errno);
+                            DMA_SetErrCode(EPERM_RBSP, p_errno);
                             check_table_flag = true;
                         }
                         cfg_table_count++;
@@ -723,19 +723,19 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                             break;
 
                             case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                             break;
 
                             case DMA_CH_TRANSFER:
-                                error_code = EBUSY;
+                                error_code = EBUSY_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                             break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -749,14 +749,14 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     return retval;
@@ -778,12 +778,12 @@ End of function R_DMA_SetParam
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EBUSY : It has been start DMA transfer in channel.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EPERM : The value in p_ch_setup isn't in the right range.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EBUSY_RBSP : It has been start DMA transfer in channel.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EPERM_RBSP : The value in p_ch_setup isn't in the right range.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -815,7 +815,7 @@ int_t R_DMA_Start(const int_t channel, const dma_trans_data_t * const p_dma_data
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EPERM, p_errno);
+                DMA_SetErrCode(EPERM_RBSP, p_errno);
             }
 
             if (ESUCCESS == retval)
@@ -841,19 +841,19 @@ int_t R_DMA_Start(const int_t channel, const dma_trans_data_t * const p_dma_data
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                              break;
 
                              case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                              break;
 
                             case DMA_CH_TRANSFER:
-                                error_code = EBUSY;
+                                error_code = EBUSY_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                              break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -865,14 +865,14 @@ int_t R_DMA_Start(const int_t channel, const dma_trans_data_t * const p_dma_data
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();
@@ -896,12 +896,12 @@ End of function R_DMA_Start
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EBUSY : It has been set continous DMA transfer.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EPERM : The value in p_ch_setup isn't in the right range.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EBUSY_RBSP : It has been set continous DMA transfer.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EPERM_RBSP : The value in p_ch_setup isn't in the right range.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -933,7 +933,7 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EPERM, p_errno);
+                DMA_SetErrCode(EPERM_RBSP, p_errno);
             }
 
             if (ESUCCESS == retval)
@@ -954,7 +954,7 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
                         {
                             /* set error return value */
                             retval = EERROR;
-                            DMA_SetErrCode(EBUSY, p_errno);
+                            DMA_SetErrCode(EBUSY_RBSP, p_errno);
                         }
                     }
                     else
@@ -964,15 +964,15 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                             break;
 
                             case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                             break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -984,14 +984,14 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();
@@ -1015,10 +1015,10 @@ End of function R_DMA_NextData
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT or DMA_CH_OPEN. (DMA stopped)
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_remain is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT or DMA_CH_OPEN. (DMA stopped)
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_remain is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -1060,19 +1060,19 @@ int_t R_DMA_Cancel(const int_t channel, uint32_t * const p_remain, int32_t * con
                     switch (dma_info_ch->ch_stat)
                     {
                         case DMA_CH_UNINIT:
-                            error_code = ENOTSUP;
+                            error_code = ENOTSUP_RBSP;
                         break;
 
                         case DMA_CH_INIT:
-                            error_code = EBADF;
+                            error_code = EBADF_RBSP;
                         break;
 
                         case DMA_CH_OPEN:
-                            error_code = EBADF;
+                            error_code = EBADF_RBSP;
                         break;
 
                         default:
-                            error_code = EFAULT;
+                            error_code = EFAULT_RBSP;
                         break;
                     }
                     DMA_SetErrCode(error_code, p_errno);
@@ -1083,14 +1083,14 @@ int_t R_DMA_Cancel(const int_t channel, uint32_t * const p_remain, int32_t * con
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux.c
@@ -349,8 +349,8 @@ End of function SCUX_GetSsifChInfo
 *                EERROR -
 *                  Error occured.
 *                    error code -
-*                       ENOMEM : Making semaphore is failed.
-*                       EFAULT : Internal error is occured.
+*                       ENOMEM_RBSP : Making semaphore is failed.
+*                       EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 int_t SCUX_InitializeOne(const int_t channel, const scux_channel_cfg_t * const p_scux_init_param)
 {
@@ -370,11 +370,11 @@ int_t SCUX_InitializeOne(const int_t channel, const scux_channel_cfg_t * const p
 
     if (NULL == p_scux_init_param)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else if (false == p_scux_init_param->enabled)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -436,7 +436,7 @@ int_t SCUX_InitializeOne(const int_t channel, const scux_channel_cfg_t * const p
 
         if (false == init_start_flag)
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -624,7 +624,7 @@ int_t SCUX_InitializeOne(const int_t channel, const scux_channel_cfg_t * const p
                 gb_scux_info_drv.info_ch[scux_ch_count].sem_ch_scux_access = osSemaphoreNew(0xffff, 1, p_semdef_ch_scux_access[scux_ch_count]);
                 if (NULL == gb_scux_info_drv.info_ch[scux_ch_count].sem_ch_scux_access)
                 {
-                     retval = ENOMEM;
+                     retval = ENOMEM_RBSP;
                 }
                 if ((ESUCCESS == retval) && (false == init_shared_flag))
                 {
@@ -633,7 +633,7 @@ int_t SCUX_InitializeOne(const int_t channel, const scux_channel_cfg_t * const p
                         gb_scux_ssif_info[ssif_ch_count].sem_ch_scux_ssif_access = osSemaphoreNew(0xffff, 1, p_semdef_ch_scux_ssif_access[ssif_ch_count]);
                         if (NULL == gb_scux_ssif_info[ssif_ch_count].sem_ch_scux_ssif_access)
                         {
-                            retval = ENOMEM;
+                            retval = ENOMEM_RBSP;
                         }
                     }
                 }
@@ -642,7 +642,7 @@ int_t SCUX_InitializeOne(const int_t channel, const scux_channel_cfg_t * const p
                     gb_scux_info_drv.shared_info.sem_shared_access = osSemaphoreNew(0xffff, 1, osSemaphore(scux_shared_access));
                     if (NULL == gb_scux_info_drv.shared_info.sem_shared_access)
                     {
-                        retval = ENOMEM;
+                        retval = ENOMEM_RBSP;
                     }
                 }
                 
@@ -663,7 +663,7 @@ int_t SCUX_InitializeOne(const int_t channel, const scux_channel_cfg_t * const p
                     if (osOK != sem_ercd)
                     {
                         /* set error return value */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
 
                     gb_scux_info_drv.info_ch[scux_ch_count].sem_ch_scux_access = NULL;
@@ -869,8 +869,8 @@ End of function SCUX_UnInitializeOne
 *                EERROR -
 *                  Error occured.
 *                    error code -
-*                       ENOMEM : Making semaphore is failed.
-*                       EFAULT : Internal error is occured.
+*                       ENOMEM_RBSP : Making semaphore is failed.
+*                       EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
 {
@@ -885,7 +885,7 @@ int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
 
     if (NULL == p_scux_init_param)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1083,7 +1083,7 @@ int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
                 gb_scux_info_drv.info_ch[scux_ch_count].sem_ch_scux_access = osSemaphoreNew(0xffff, 1, p_semdef_ch_scux_access[scux_ch_count]);
                 if (NULL == gb_scux_info_drv.info_ch[scux_ch_count].sem_ch_scux_access)
                 {
-                     retval = ENOMEM;
+                     retval = ENOMEM_RBSP;
                 }
                 if ((ESUCCESS == retval) && (false == init_shared_flag))
                 {
@@ -1092,7 +1092,7 @@ int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
                         gb_scux_ssif_info[ssif_ch_count].sem_ch_scux_ssif_access = osSemaphoreNew(0xffff, 1, p_semdef_ch_scux_ssif_access[ssif_ch_count]);
                         if (NULL == gb_scux_ssif_info[ssif_ch_count].sem_ch_scux_ssif_access)
                         {
-                            retval = ENOMEM;
+                            retval = ENOMEM_RBSP;
                         }
                     }
                 }
@@ -1101,7 +1101,7 @@ int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
                     gb_scux_info_drv.shared_info.sem_shared_access = osSemaphoreNew(0xffff, 1, osSemaphore(scux_shared_access));
                     if (NULL == gb_scux_info_drv.shared_info.sem_shared_access)
                     {
-                        retval = ENOMEM;
+                        retval = ENOMEM_RBSP;
                     }
                 }
 
@@ -1127,7 +1127,7 @@ int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
                 if (osOK != sem_ercd)
                 {
                     /* set error return value */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
 
                 gb_scux_info_drv.info_ch[scux_ch_count].enabled = false;
@@ -1142,7 +1142,7 @@ int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
             if (osOK != sem_ercd)
             {
                 /* set error return value */
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
         }
 
@@ -1151,7 +1151,7 @@ int_t SCUX_Initialize(const scux_channel_cfg_t * const p_scux_init_param)
         if (osOK != sem_ercd)
         {
             /* set error return value */
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
 
         gb_scux_info_drv.drv_stat = SCUX_DRV_UNINIT;
@@ -1312,8 +1312,8 @@ End of function SCUX_UnInitialize
 * @param[in]     flags:specifies the access mode whether the channel is
 *                      opened for a read or a write
 * @retval        ESUCCESS: Operation successful.
-*                ENOMEM: Create queue is failed.
-*                EMFILE: Allocate DMA ch for write is failed.
+*                ENOMEM_RBSP: Create queue is failed.
+*                EMFILE_RBSP: Allocate DMA ch for write is failed.
 ******************************************************************************/
 
 int_t SCUX_OpenChannel(const int_t channel, const int_t flags)
@@ -1324,7 +1324,7 @@ int_t SCUX_OpenChannel(const int_t channel, const int_t flags)
     retval = ahf_create(&gb_scux_info_drv.info_ch[channel].tx_que, AHF_LOCKINT);
     if (ESUCCESS != retval)
     {
-        retval = ENOMEM;
+        retval = ENOMEM_RBSP;
     }
     else
     {
@@ -1332,7 +1332,7 @@ int_t SCUX_OpenChannel(const int_t channel, const int_t flags)
         retval = ahf_create(&gb_scux_info_drv.info_ch[channel].rx_que, AHF_LOCKINT);
         if (ESUCCESS != retval)
         {
-            retval = ENOMEM;
+            retval = ENOMEM_RBSP;
         }
     }
 
@@ -1357,7 +1357,7 @@ int_t SCUX_OpenChannel(const int_t channel, const int_t flags)
         gb_scux_info_drv.info_ch[channel].dma_tx_ch = R_DMA_Alloc(DMA_ALLOC_CH, NULL);
         if (EERROR == gb_scux_info_drv.info_ch[channel].dma_tx_ch)
         {
-            retval = EMFILE;
+            retval = EMFILE_RBSP;
         }
         else
         {
@@ -1381,7 +1381,7 @@ End of function SCUX_OpenChannel
 *
 * @param[in]     channel: SCUX channel number.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t  SCUX_CloseChannel(const int_t channel)
@@ -1400,7 +1400,7 @@ int_t  SCUX_CloseChannel(const int_t channel)
         ercd = SCUX_IoctlClearStop(channel);
         if (ESUCCESS != ercd)
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
     }
 
@@ -1417,7 +1417,7 @@ int_t  SCUX_CloseChannel(const int_t channel)
         ercd = R_DMA_Free(gb_scux_info_drv.info_ch[channel].dma_tx_ch, NULL);
         if (ESUCCESS != ercd)
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -1444,11 +1444,11 @@ End of function SCUX_CloseChannel
 *
 * @param[in]     *p_scux_info_ch:SCUX channel information.
 * @retval        ESUCCESS : Parameter is no problems.
-*                EACCES : DVU setting isn't performed when DVU is used.
-*                EACCES : MIX setting isn't performed when MIX is used.
-*                EACCES : SSIF setting isn't performed when SSIF is used.
-*                EPERM : Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EACCES_RBSP : DVU setting isn't performed when DVU is used.
+*                EACCES_RBSP : MIX setting isn't performed when MIX is used.
+*                EACCES_RBSP : SSIF setting isn't performed when SSIF is used.
+*                EPERM_RBSP : Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
@@ -1459,7 +1459,7 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
 
     if (NULL == p_scux_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1468,7 +1468,7 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
             ((SCUX_ROUTE_SRC_SSIF_MIN >= p_scux_info_ch->route_set) || (SCUX_ROUTE_SRC_SSIF_MAX <= p_scux_info_ch->route_set)) &&
             ((SCUX_ROUTE_SRC_MIX_SSIF_MIN >= p_scux_info_ch->route_set) || (SCUX_ROUTE_SRC_MIX_SSIF_MAX <= p_scux_info_ch->route_set)))
         {
-            retval = EPERM;
+            retval = EPERM_RBSP;
         }
         else
         {
@@ -1490,7 +1490,7 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
                         (SCUX_ROUTE_SRC0_MIX_SSIF012 != p_scux_info_ch->route_set))
 #endif /* mbed */
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 break;
 
@@ -1509,7 +1509,7 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
                         (SCUX_ROUTE_SRC1_MIX_SSIF012 != p_scux_info_ch->route_set))
 #endif /* mbed */
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 break;
 
@@ -1526,7 +1526,7 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
                         (SCUX_ROUTE_SRC2_MIX_SSIF012 != p_scux_info_ch->route_set))
 #endif /* mbed */
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 break;
 
@@ -1543,13 +1543,13 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
                         (SCUX_ROUTE_SRC3_MIX_SSIF012 != p_scux_info_ch->route_set))
 #endif /* mbed */
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 break;
 
                 default :
                     /* NOTREACHED on At the time of a normal performance */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 break;
 
             }
@@ -1740,7 +1740,7 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
 #endif /* mbed */
                 default :
                     /* NOTREACHED on At the time of a normal performance */
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 break;
             }
         }
@@ -1756,7 +1756,7 @@ int_t SCUX_CheckParam(scux_info_ch_t * const p_scux_info_ch)
                 if (false != p_scux_info_ch->src_cfg.mode_sync)
                 {
                     /* src disable is async mode only */
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
             }
         }
@@ -1798,8 +1798,8 @@ End of function SCUX_CheckParam
 * @param[in]     ssif_ch : Used ssif channel number.
 * @param[in]     use_mix_flag : Flag of Using MIX .
 * @retval        ESUCCESS : Parameter is no problems.
-*                EPERM : Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EPERM_RBSP : Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uint32_t ssif_ch[SCUX_SSIF_NUM_CH_ARRANGEMENT])
@@ -1815,7 +1815,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
 
     if ((NULL == p_scux_info_ch) || (NULL == ssif_ch))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1828,7 +1828,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                 (SCUX_USE_CH_6 != p_scux_info_ch->src_cfg.use_ch) &&
                 (SCUX_USE_CH_8 != p_scux_info_ch->src_cfg.use_ch))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
         else
@@ -1836,7 +1836,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
             /* on SCUX2, SCUX3, enable audio channel is only 1ch and 2ch */
             if ((SCUX_USE_CH_1 != p_scux_info_ch->src_cfg.use_ch) && (SCUX_USE_CH_2 != p_scux_info_ch->src_cfg.use_ch))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1845,7 +1845,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
             /* if using SSIF, 1ch audio channel is disabled */
             if ((SCUX_SSIF_NO_USE_CH != ssif_ch[SCUX_SSIF_CH_ARRANGEMENT1]) && (SCUX_USE_CH_1 == p_scux_info_ch->src_cfg.use_ch))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1860,7 +1860,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                     {
                         if (SCUX_USE_CH_2 == p_scux_info_ch->src_cfg.use_ch)
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
                 }
@@ -1872,7 +1872,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
             /* multiple SSIF ch check (multiple SSIF is used SSIF2) */
             if ((SCUX_SSIF_NO_USE_CH != ssif_ch[SCUX_SSIF_CH_ARRANGEMENT2]) && (SCUX_USE_CH_6 != p_scux_info_ch->src_cfg.use_ch))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1881,7 +1881,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
             /* check word length */
             if ((SCUX_DATA_LEN_MIN >= p_scux_info_ch->src_cfg.word_len) || (SCUX_DATA_LEN_MAX <= p_scux_info_ch->src_cfg.word_len))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1890,14 +1890,14 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
             /* check delay mode */
             if ((SCUX_DELAY_MIN >= p_scux_info_ch->src_cfg.delay_mode) || (SCUX_DELAY_MAX <= p_scux_info_ch->src_cfg.delay_mode))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
             else
             {
                 /* enable audio channel is less than 2ch when delay mode is enabled */
                 if ((SCUX_DELAY_NORMAL != p_scux_info_ch->src_cfg.delay_mode) && (SCUX_USE_CH_2 < p_scux_info_ch->src_cfg.use_ch))
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
             }
         }
@@ -1926,7 +1926,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         ((SCUX_SYNC_RATE_88_2 == p_scux_info_ch->src_cfg.input_rate_sync) ||
                          (SCUX_SYNC_RATE_96 == p_scux_info_ch->src_cfg.input_rate_sync)))
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
 
                     /* enable rate is less than 49KHz on 8ch */
@@ -1935,12 +1935,12 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                          (SCUX_SYNC_RATE_88_2 == p_scux_info_ch->src_cfg.input_rate_sync) ||
                          (SCUX_SYNC_RATE_96 == p_scux_info_ch->src_cfg.input_rate_sync)))
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 }
                 else
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
 
                 if (ESUCCESS == retval) {
@@ -1957,12 +1957,12 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         if ((SCUX_USE_CH_6 <= p_scux_info_ch->src_cfg.use_ch) &&
                             (SCUX_SYNC_RATE_96 == p_scux_info_ch->src_cfg.output_rate_sync))
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
                     else
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 }
 
@@ -2003,7 +2003,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         freq_value = p_scux_info_ch->src_cfg.freq_tioc3a;
                         if (0U == freq_value)
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     break;
 
@@ -2011,7 +2011,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         freq_value = p_scux_info_ch->src_cfg.freq_tioc4a;
                         if (0U == freq_value)
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     break;
 
@@ -2031,13 +2031,13 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         freq_value = p_scux_info_ch->src_cfg.input_ws;
                         if (0U == freq_value)
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     break;
 
                     default :
                         /* NOTREACHED on At the time of a normal performance */
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     break;
                 }
 
@@ -2059,7 +2059,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         if ((0U != (p_scux_info_ch->src_cfg.input_div_async % SCUX_EVEN_VALUE_DIV)) ||
                             (SCUX_MAX_DIV_CLK < p_scux_info_ch->src_cfg.input_div_async))
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                         else
                         {
@@ -2097,7 +2097,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         if ((SCUX_MIN_FREQ > p_scux_info_ch->input_rate) ||
                            (max_rate < p_scux_info_ch->input_rate))
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
                 }
@@ -2124,7 +2124,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         }
                         else
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
                     else
@@ -2157,7 +2157,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                                 freq_value = p_scux_info_ch->src_cfg.freq_tioc3a;
                                 if (0U == freq_value)
                                 {
-                                    retval = EPERM;
+                                    retval = EPERM_RBSP;
                                 }
                             break;
 
@@ -2165,7 +2165,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                                 freq_value = p_scux_info_ch->src_cfg.freq_tioc4a;
                                 if (0U == freq_value)
                                 {
-                                    retval = EPERM;
+                                    retval = EPERM_RBSP;
                                 }
                             break;
 
@@ -2185,7 +2185,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                                 freq_value = p_scux_info_ch->src_cfg.output_ws;
                                 if (0U == freq_value)
                                 {
-                                    retval = EPERM;
+                                    retval = EPERM_RBSP;
                                 }
                             break;
 
@@ -2193,7 +2193,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                                 /* error check is gone when route is other than SSIF */
                                 if (SCUX_ROUTE_SSIF != (p_scux_info_ch->route_set & SCUX_GET_ROUTE_MASK))
                                 {
-                                    retval = EPERM;
+                                    retval = EPERM_RBSP;
                                 }
                             break;
                         }
@@ -2216,7 +2216,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                             if ((0U != (p_scux_info_ch->src_cfg.output_div_async % SCUX_EVEN_VALUE_DIV)) ||
                                 (SCUX_MAX_DIV_CLK < p_scux_info_ch->src_cfg.output_div_async))
                             {
-                                retval = EPERM;
+                                retval = EPERM_RBSP;
                             }
                         }
                     }
@@ -2266,7 +2266,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                         if ((SCUX_MIN_FREQ > p_scux_info_ch->output_rate) ||
                             (max_rate < p_scux_info_ch->output_rate))
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
 
                     }
@@ -2302,7 +2302,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
 
                             default :
                                 /* NOTREACHED on At the time of a normal performance */
-                                retval = EPERM;
+                                retval = EPERM_RBSP;
                             break;
                         }
                     break;
@@ -2317,14 +2317,14 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
 
                     default :
                         /* NOTREACHED on At the time of a normal performance */
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     break;
                 }
 
                 rate_sample_ratio = ((p_scux_info_ch->output_rate * SCUX_RATE_INT_CONV_VALUE) / p_scux_info_ch->input_rate);
                 if ((min_conv_rate > rate_sample_ratio) || (max_conv_rate < rate_sample_ratio))
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
             }
         }
@@ -2334,7 +2334,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
             /* check wait time */
             if (SCUX_MAX_WAIT_TIME < p_scux_info_ch->src_cfg.wait_sample)
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -2344,7 +2344,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
             if ((SCUX_MIN_RATE_MIN_PAERCENTAGE > (uint32_t)p_scux_info_ch->src_cfg.min_rate_percentage) ||
                 (SCUX_MIN_RATE_MAX_PAERCENTAGE < (uint32_t)p_scux_info_ch->src_cfg.min_rate_percentage))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -2356,7 +2356,7 @@ static int_t SCUX_CheckSrcParam(scux_info_ch_t * const p_scux_info_ch, const uin
                 if ((SCUX_AUDIO_CH_MIN >= p_scux_info_ch->src_cfg.select_in_data_ch[audio_ch]) ||
                     (SCUX_AUDIO_CH_MAX <= p_scux_info_ch->src_cfg.select_in_data_ch[audio_ch]))
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
             }
         }
@@ -2377,9 +2377,9 @@ End of function SCUX_CheckSrcParam
 *
 * @param[in]     *p_scux_info_ch:SCUX channel information.
 * @retval        ESUCCESS : Parameter is no problems.
-*                EACCES : DVU setting isn't performed when DVU is used.
-*                EPERM : Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EACCES_RBSP : DVU setting isn't performed when DVU is used.
+*                EPERM_RBSP : Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 static int_t SCUX_CheckDvuParam(const scux_info_ch_t * const p_scux_info_ch)
@@ -2390,13 +2390,13 @@ static int_t SCUX_CheckDvuParam(const scux_info_ch_t * const p_scux_info_ch)
 
     if (NULL == p_scux_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
         if (false == p_scux_info_ch->dvu_setup)
         {
-            retval = EACCES;
+            retval = EACCES_RBSP;
         }
         else
         {
@@ -2410,7 +2410,7 @@ static int_t SCUX_CheckDvuParam(const scux_info_ch_t * const p_scux_info_ch)
                     {
                         if (SCUX_MAX_DIGITAL_VOLUME < p_scux_info_ch->dvu_cfg.dvu_digi_vol.digi_vol[audio_ch])
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
                 }
@@ -2427,7 +2427,7 @@ static int_t SCUX_CheckDvuParam(const scux_info_ch_t * const p_scux_info_ch)
                     if ((p_scux_info_ch->dvu_cfg.dvu_ramp_vol.up_period <= SCUX_DVU_TIME_MIN) ||
                         (p_scux_info_ch->dvu_cfg.dvu_ramp_vol.up_period >= SCUX_DVU_TIME_MAX))
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
 
                     if (ESUCCESS == retval)
@@ -2436,7 +2436,7 @@ static int_t SCUX_CheckDvuParam(const scux_info_ch_t * const p_scux_info_ch)
                         if ((p_scux_info_ch->dvu_cfg.dvu_ramp_vol.down_period <= SCUX_DVU_TIME_MIN) ||
                             (p_scux_info_ch->dvu_cfg.dvu_ramp_vol.down_period >= SCUX_DVU_TIME_MAX))
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
 
@@ -2445,7 +2445,7 @@ static int_t SCUX_CheckDvuParam(const scux_info_ch_t * const p_scux_info_ch)
                         /* check ramp volume */
                         if (SCUX_MAX_RAMP_VOLUME < p_scux_info_ch->dvu_cfg.dvu_ramp_vol.ramp_vol)
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
 
@@ -2454,7 +2454,7 @@ static int_t SCUX_CheckDvuParam(const scux_info_ch_t * const p_scux_info_ch)
                         /* check wait time */
                         if (SCUX_MAX_WAIT_TIME < p_scux_info_ch->dvu_cfg.dvu_ramp_vol.ramp_wait_time)
                         {
-                            retval = EPERM;
+                            retval = EPERM_RBSP;
                         }
                     }
                 }
@@ -2479,11 +2479,11 @@ End of function SCUX_CheckDvuParam
 * @param[in]     ssif_ch : Used ssif channel number.
 * @param[in]     use_mix_flag : Flag of Using MIX .
 * @retval        ESUCCESS : Parameter is no problems.
-*                EACCES : SSIF setting isn't performed when SSIF is used.
-*                EACCES : SSIF channel is already used.
-*                EACCES : When use MIX, it is a setup which does not agree in a route setup.
-*                EPERM : Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EACCES_RBSP : SSIF setting isn't performed when SSIF is used.
+*                EACCES_RBSP : SSIF channel is already used.
+*                EACCES_RBSP : When use MIX, it is a setup which does not agree in a route setup.
+*                EPERM_RBSP : Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const uint32_t ssif_ch[SCUX_SSIF_NUM_CH_ARRANGEMENT], const bool_t use_mix_flag)
@@ -2495,7 +2495,7 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
 
     if ((NULL == p_info_drv) || (NULL == p_scux_info_ch) || (NULL == ssif_ch))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -2509,14 +2509,14 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
                     /* check SSIF is already setup */
                     if (false == gb_scux_ssif_info[ssif_ch[ssif_arrange_num]].ssif_setup)
                     {
-                        retval = EACCES;
+                        retval = EACCES_RBSP;
                     }
                     else
                     {
                         /* used SSIF channel is checked by other SCUX channel */
                         if (0 != gb_scux_ssif_info[ssif_ch[ssif_arrange_num]].scux_channel)
                         {
-                            retval = EACCES;
+                            retval = EACCES_RBSP;
                         }
                     }
                 }
@@ -2534,7 +2534,7 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
                     /* check SSIF is already setup */
                     if (false == gb_scux_ssif_info[ssif_ch[ssif_arrange_num]].ssif_setup)
                     {
-                        retval = EACCES;
+                        retval = EACCES_RBSP;
                     }
                 }
             }
@@ -2546,7 +2546,7 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
                     /* In the MIX setup for the and after 2times, it is checked that same SSIF ch on 1st setting is set up */
                     if (p_info_drv->shared_info.mix_ssif_ch != mix_ssif_ch_bit)
                     {
-                        retval = EACCES;
+                        retval = EACCES_RBSP;
                     }
                 }
                 else
@@ -2558,14 +2558,14 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
                             (0 != gb_scux_ssif_info[ssif_ch[SCUX_SSIF_CH_ARRANGEMENT2]].scux_channel) ||
                             (0 != gb_scux_ssif_info[ssif_ch[SCUX_SSIF_CH_ARRANGEMENT3]].scux_channel))
                         {
-                            retval = EACCES;
+                            retval = EACCES_RBSP;
                         }
                     }
                     else
                     {
                         if (0 != gb_scux_ssif_info[ssif_ch[SCUX_SSIF_CH_ARRANGEMENT1]].scux_channel)
                         {
-                            retval = EACCES;
+                            retval = EACCES_RBSP;
                         }
                     }
                 }
@@ -2583,7 +2583,7 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
                 if ((gb_scux_ssif_info[ssif_ch[ssif_arrange_num]].ssif_cfg.system_word <= SCUX_SSIF_SYSTEM_LEN_MIN) ||
                     (gb_scux_ssif_info[ssif_ch[ssif_arrange_num]].ssif_cfg.system_word >= SCUX_SSIF_SYSTEM_LEN_MAX))
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
                 else
                 {
@@ -2592,7 +2592,7 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
                     if ((SCUX_DATA_LEN_16 != p_scux_info_ch->src_cfg.word_len) &&
                         (SCUX_SSIF_SYSTEM_LEN_16 == gb_scux_ssif_info[ssif_ch[ssif_arrange_num]].ssif_cfg.system_word))
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 }
 
@@ -2602,7 +2602,7 @@ static int_t SCUX_CheckSsifParam(scux_info_ch_t * const p_scux_info_ch, const ui
                     if ((SCUX_SSIF_NO_USE_CH != ssif_ch[SCUX_SSIF_CH_ARRANGEMENT2]) &&
                         (false != gb_scux_ssif_info[ssif_ch[ssif_arrange_num]].ssif_cfg.use_tdm))
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 }
                 if (ESUCCESS == retval)
@@ -2651,9 +2651,9 @@ End of function SCUX_CheckSsifParam
 *
 * @param[in]     *p_scux_info_ch:SCUX channel information.
 * @retval        ESUCCESS : Parameter is no problems.
-*                EACCES : MIX setting isn't performed when MIX is used.
-*                EPERM : Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EACCES_RBSP : MIX setting isn't performed when MIX is used.
+*                EPERM_RBSP : Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 static int_t SCUX_CheckMixParam(const scux_info_ch_t * const p_scux_info_ch)
@@ -2665,13 +2665,13 @@ static int_t SCUX_CheckMixParam(const scux_info_ch_t * const p_scux_info_ch)
 
     if ((NULL == p_info_drv) || (NULL == p_scux_info_ch))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
         if (false == p_info_drv->shared_info.mix_setup)
         {
-            retval = EACCES;
+            retval = EACCES_RBSP;
         }
         else
         {
@@ -2681,14 +2681,14 @@ static int_t SCUX_CheckMixParam(const scux_info_ch_t * const p_scux_info_ch)
                 if ((SCUX_MIX_TIME_MIN >= p_info_drv->shared_info.up_period) ||
                     (SCUX_MIX_TIME_MAX <= p_info_drv->shared_info.up_period))
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
 
                 /* check ramp down time */
                 if ((SCUX_MIX_TIME_MIN >= p_info_drv->shared_info.down_period) ||
                     (SCUX_MIX_TIME_MAX <= p_info_drv->shared_info.down_period))
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
             }
 
@@ -2701,7 +2701,7 @@ static int_t SCUX_CheckMixParam(const scux_info_ch_t * const p_scux_info_ch)
                 {
                     if (SCUX_MAX_RAMP_VOLUME < p_info_drv->shared_info.mix_vol[scux_ch])
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 }
             }
@@ -2713,7 +2713,7 @@ static int_t SCUX_CheckMixParam(const scux_info_ch_t * const p_scux_info_ch)
                 if ((SCUX_AUDIO_CH_MIN >= p_info_drv->shared_info.select_out_data_ch[audio_ch]) ||
                     (SCUX_AUDIO_CH_MAX <= p_info_drv->shared_info.select_out_data_ch[audio_ch]))
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
             }
         }
@@ -2771,7 +2771,7 @@ End of function SCUX_StrNLen
 *                
 * @param[in]     None.
 * @retval        ESUCCESS : Parameter is no problems.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 static int_t SCUX_CmnUnInitialize(void)
 {
@@ -2793,7 +2793,7 @@ static int_t SCUX_CmnUnInitialize(void)
             if (osOK != sem_ercd)
             {
                 /* set error return value */
-                 retval = EFAULT;
+                 retval = EFAULT_RBSP;
             }
 
             gb_scux_ssif_info[ssif_ch_count].sem_ch_scux_ssif_access = NULL;
@@ -2807,7 +2807,7 @@ static int_t SCUX_CmnUnInitialize(void)
         if (osOK != sem_ercd)
         {
             /* set error return value */
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
 
         gb_scux_info_drv.shared_info.sem_shared_access = NULL;

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_board.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_board.c
@@ -47,8 +47,8 @@ Exported global variables (to be accessed by other files)
 * @param[in]     *p_scux_info_ch : SCUX channel information.
 * @param[in]     ssif_ch : Used ssif channel number.
 * @retval        ESUCCESS : Parameter is no problems.
-*                EPERM : Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EPERM_RBSP : Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_CheckSsifClockDiv(const scux_info_ch_t * const p_scux_info_ch, const uint32_t ssif_ch_num)
@@ -67,7 +67,7 @@ int_t SCUX_CheckSsifClockDiv(const scux_info_ch_t * const p_scux_info_ch, const 
 
     if ((NULL == p_scux_info_ch) || (NULL == p_ssif_ch))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -91,7 +91,7 @@ int_t SCUX_CheckSsifClockDiv(const scux_info_ch_t * const p_scux_info_ch, const 
 
             if (0u == input_clk)
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
 
             if (ESUCCESS == retval)
@@ -127,7 +127,7 @@ int_t SCUX_CheckSsifClockDiv(const scux_info_ch_t * const p_scux_info_ch, const 
                     break;
 
                     default :
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     break;
                 }
 
@@ -145,7 +145,7 @@ int_t SCUX_CheckSsifClockDiv(const scux_info_ch_t * const p_scux_info_ch, const 
                 dot_clk = syswd_len * n_syswd_per_smp * smp_freq;
                 if (0u == dot_clk)
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
                 else
                 {
@@ -155,7 +155,7 @@ int_t SCUX_CheckSsifClockDiv(const scux_info_ch_t * const p_scux_info_ch, const 
                     if (0U != result)
                     {
                         /* cannot create dotclock from input audio clock */
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                     else
                     {
@@ -216,7 +216,7 @@ int_t SCUX_CheckSsifClockDiv(const scux_info_ch_t * const p_scux_info_ch, const 
                             break;
 
                             default:
-                                retval = EPERM;
+                                retval = EPERM_RBSP;
                             break;
                         }
                     }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_dev.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_dev.c
@@ -116,7 +116,7 @@ static void  SCUX_DMA_DirectTxCallBack(union sigval const param);
 * @param[in]     *p_scux_info_ch:SCUX channel information.
 * @param[in]     *p_write_aio:Write request information.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_CopyWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_write_aio)
@@ -133,7 +133,7 @@ int_t SCUX_CopyWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p
 
     if ((NULL == p_scux_info_ch) || (NULL == p_write_aio))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -141,7 +141,7 @@ int_t SCUX_CopyWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p
 
         if (ESUCCESS != retval)
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -161,7 +161,7 @@ int_t SCUX_CopyWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p
             dma_retval = R_DMA_Start(p_scux_info_ch->dma_tx_ch, &dma_address_param, &ret);
             if (ESUCCESS != dma_retval)
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -197,7 +197,7 @@ int_t SCUX_CopyWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p
                     case SCUX_CH_INIT :
                         /* fall through */
                     case SCUX_CH_STOP :
-                        retval = EBADF;
+                        retval = EBADF_RBSP;
                     break;
 
                     case SCUX_CH_TRANS_IDLE :
@@ -219,7 +219,7 @@ int_t SCUX_CopyWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p
                     break;
 
                     default :
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                         /* NOTREACHED on At the time of a normal performance */
                     break;
                 }
@@ -243,7 +243,7 @@ End of function SCUX_CopyWriteStart
 * @param[in]     *p_scux_info_ch:SCUX channel information.
 * @param[in]     *p_write_aio:Write request information.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_write_aio)
@@ -262,7 +262,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
 
     if ((NULL == p_scux_info_ch) || (NULL == p_write_aio))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -270,7 +270,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
 
         if (ESUCCESS != retval)
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -295,7 +295,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
 
             if (ESUCCESS != dma_retval)
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -308,7 +308,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
                 dma_retval = R_DMA_Start(p_scux_info_ch->dma_tx_ch, &dma_address_param, &ret);
                 if (ESUCCESS != dma_retval)
                 {
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
                 else
                 {
@@ -329,7 +329,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
                             /* fall through */
                         case SCUX_CH_STOP :
                             /* fall through */
-                            retval = EBADF;
+                            retval = EBADF_RBSP;
                         break;
 
                         case SCUX_CH_TRANS_IDLE :
@@ -338,7 +338,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
 
                         case SCUX_CH_TRANS_RD :
                             /* read function disabled */
-                            retval = EFAULT;
+                            retval = EFAULT_RBSP;
                         break;
 
                         case SCUX_CH_TRANS_WR :
@@ -347,7 +347,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
 
                         case SCUX_CH_TRANS_RDWR :
                             /* read function disabled */
-                            retval = EFAULT;
+                            retval = EFAULT_RBSP;
                         break;
 
                         case SCUX_CH_STOP_WAIT :
@@ -356,12 +356,12 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
 
                         case SCUX_CH_STOP_WAIT_IDLE :
                             /* read function disabled */
-                            retval = EFAULT;
+                            retval = EFAULT_RBSP;
                         break;
 
                         default :
                             /* NOTREACHED on At the time of a normal performance */
-                            retval = EFAULT;
+                            retval = EFAULT_RBSP;
                         break;
                     }
 
@@ -375,7 +375,7 @@ int_t SCUX_DirectWriteStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const
                         }
                         if (SCUX_RAMP_WAIT_MAX <= ramp_wait_cnt)
                         {
-                            retval = EFAULT;
+                            retval = EFAULT_RBSP;
                         }
                         else
                         {
@@ -406,7 +406,7 @@ End of function SCUX_DirectWriteStart
 * @param[in]     *p_scux_info_ch:SCUX channel information.
 * @param[in]     *p_read_aio:Read request information.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_CopyReadStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_read_aio)
@@ -418,7 +418,7 @@ int_t SCUX_CopyReadStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_
 
     if ((NULL == p_scux_info_ch) || (NULL == p_read_aio))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -426,7 +426,7 @@ int_t SCUX_CopyReadStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_
 
         if (ESUCCESS != retval)
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -447,7 +447,7 @@ int_t SCUX_CopyReadStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_
 
             if (ESUCCESS != dma_retval)
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -485,7 +485,7 @@ int_t SCUX_CopyReadStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_
                         /* fall through */
                     case SCUX_CH_STOP :
                         /* fall through */
-                        retval = EBADF;
+                        retval = EBADF_RBSP;
                     break;
 
                     case SCUX_CH_TRANS_IDLE :
@@ -512,7 +512,7 @@ int_t SCUX_CopyReadStart(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_
 
                     default :
                         /* NOTREACHED on At the time of a normal performance */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     break;
                 }
             }
@@ -535,7 +535,7 @@ End of function SCUX_CopyReadStart
 * @param[in]     *p_scux_info_ch:SCUX channel information.
 * @param[in]     *p_write_aio:Write request information.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_FlushWriteStart(scux_info_ch_t * const p_scux_info_ch)
@@ -545,7 +545,7 @@ int_t SCUX_FlushWriteStart(scux_info_ch_t * const p_scux_info_ch)
 
     if (NULL == p_scux_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -555,7 +555,7 @@ int_t SCUX_FlushWriteStart(scux_info_ch_t * const p_scux_info_ch)
 
             if (ESUCCESS != retval)
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -578,7 +578,7 @@ int_t SCUX_FlushWriteStart(scux_info_ch_t * const p_scux_info_ch)
                 retval = R_DMA_Start(p_scux_info_ch->dma_tx_ch, &dma_address_param, NULL);
                 if (ESUCCESS != retval)
                 {
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
                 else
                 {
@@ -634,8 +634,8 @@ End of function SCUX_FlushWriteStart
 * @param[in]     *p_scux_info_ch : SCUX channel information.
 * @param[in]     *p_cancel_aio : Cancel request information.
 * @retval        ESUCCESS : Operation successful.
-*                EBUSY  : Cancel requst is on going.
-*                EFAULT : Internal error is occured.
+*                EBUSY_RBSP  : Cancel requst is on going.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 #if(1) /* mbed */
@@ -650,7 +650,7 @@ int_t SCUX_CopyCancelSpecific(scux_info_ch_t * const p_scux_info_ch, AIOCB * con
 
     if (NULL == p_scux_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -659,7 +659,7 @@ int_t SCUX_CopyCancelSpecific(scux_info_ch_t * const p_scux_info_ch, AIOCB * con
         /* check cancel request */
         if ((p_scux_info_ch->p_tx_aio == p_cancel_aio) || (p_scux_info_ch->p_rx_aio == p_cancel_aio))
         {
-            retval = EBUSY;
+            retval = EBUSY_RBSP;
         }
         else
         {
@@ -700,8 +700,8 @@ End of function SCUX_CopyCancelSpecific
 * @param[in]     *p_scux_info_ch : SCUX channel information.
 * @param[in]     *p_cancel_aio : Cancel request information.
 * @retval        ESUCCESS : Operation successful.
-*                EBUSY  : Cancel requst is on going.
-*                EFAULT : Internal error is occured.
+*                EBUSY_RBSP  : Cancel requst is on going.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_DirectCancelSpecific(scux_info_ch_t * const p_scux_info_ch, AIOCB * const p_cancel_aio)
@@ -711,7 +711,7 @@ int_t SCUX_DirectCancelSpecific(scux_info_ch_t * const p_scux_info_ch, AIOCB * c
 
     if (NULL == p_scux_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -720,7 +720,7 @@ int_t SCUX_DirectCancelSpecific(scux_info_ch_t * const p_scux_info_ch, AIOCB * c
         /* check cancel request */
         if ((p_scux_info_ch->p_tx_aio == p_cancel_aio) || (p_scux_info_ch->p_tx_next_aio == p_cancel_aio))
         {
-            retval = EBUSY;
+            retval = EBUSY_RBSP;
         }
         else
         {
@@ -750,7 +750,7 @@ End of function SCUX_DirectCancelSpecific
 *
 * @param[in]     *p_scux_info_ch : SCUX channel information.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 #if(1) /* mbed */
@@ -772,17 +772,17 @@ int_t SCUX_CopyCancelAll(scux_info_ch_t * const p_scux_info_ch)
 
     if (NULL == p_scux_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
         core_util_critical_section_enter();
 
         dma_retval = R_DMA_Cancel(p_scux_info_ch->dma_tx_ch, &tx_remain_size, &dma_ercd);
-        /* DMA stop check, (when dma_ercd is EBADF, DMA stopped already) */
-        if ((ESUCCESS != dma_retval) && (EBADF != dma_ercd))
+        /* DMA stop check, (when dma_ercd is EBADF_RBSP, DMA stopped already) */
+        if ((ESUCCESS != dma_retval) && (EBADF_RBSP != dma_ercd))
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -791,10 +791,10 @@ int_t SCUX_CopyCancelAll(scux_info_ch_t * const p_scux_info_ch)
         }
 
         dma_retval = R_DMA_Cancel(p_scux_info_ch->dma_rx_ch, &rx_remain_size, &dma_ercd);
-        /* DMA stop check, (when dma_ercd is EBADF, DMA stopped already) */
-        if ((ESUCCESS != dma_retval) && (EBADF != dma_ercd))
+        /* DMA stop check, (when dma_ercd is EBADF_RBSP, DMA stopped already) */
+        if ((ESUCCESS != dma_retval) && (EBADF_RBSP != dma_ercd))
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -807,14 +807,14 @@ int_t SCUX_CopyCancelAll(scux_info_ch_t * const p_scux_info_ch)
             /* return write request */
             if (NULL !=  p_scux_info_ch->p_tx_aio)
             {
-                p_scux_info_ch->p_tx_aio->aio_return = ECANCELED;
+                p_scux_info_ch->p_tx_aio->aio_return = ECANCELED_RBSP;
                 ahf_complete(&p_scux_info_ch->tx_que, p_scux_info_ch->p_tx_aio);
             }
 
             /* return read request */
             if (NULL != p_scux_info_ch->p_rx_aio)
             {
-                p_scux_info_ch->p_rx_aio->aio_return = ECANCELED;
+                p_scux_info_ch->p_rx_aio->aio_return = ECANCELED_RBSP;
                 ahf_complete(&p_scux_info_ch->rx_que, p_scux_info_ch->p_rx_aio);
             }
 
@@ -869,7 +869,7 @@ End of function SCUX_CopyCancelAll
 *
 * @param[in]     *p_scux_info_ch : SCUX channel information.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_DirectCancelAll(scux_info_ch_t * const p_scux_info_ch)
@@ -885,17 +885,17 @@ int_t SCUX_DirectCancelAll(scux_info_ch_t * const p_scux_info_ch)
 
     if (NULL == p_scux_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
         core_util_critical_section_enter();
 
         dma_retval = R_DMA_Cancel(p_scux_info_ch->dma_tx_ch, &tx_remain_size, &dma_ercd);
-        /* DMA stop check, (when dma_ercd is EBADF, DMA stopped already) */
-        if ((ESUCCESS != dma_retval) && (EBADF != dma_ercd))
+        /* DMA stop check, (when dma_ercd is EBADF_RBSP, DMA stopped already) */
+        if ((ESUCCESS != dma_retval) && (EBADF_RBSP != dma_ercd))
         {
-            retval = EFAULT;
+            retval = EFAULT_RBSP;
         }
         else
         {
@@ -904,12 +904,12 @@ int_t SCUX_DirectCancelAll(scux_info_ch_t * const p_scux_info_ch)
 
             if (NULL != p_scux_info_ch->p_tx_aio)
             {
-                p_scux_info_ch->p_tx_aio->aio_return = ECANCELED;
+                p_scux_info_ch->p_tx_aio->aio_return = ECANCELED_RBSP;
                 ahf_complete(&p_scux_info_ch->tx_que, p_scux_info_ch->p_tx_aio);
             }
             if (NULL != p_scux_info_ch->p_tx_next_aio)
             {
-                p_scux_info_ch->p_tx_next_aio->aio_return = ECANCELED;
+                p_scux_info_ch->p_tx_next_aio->aio_return = ECANCELED_RBSP;
                 ahf_complete(&p_scux_info_ch->tx_que, p_scux_info_ch->p_tx_next_aio);
             }
             ahf_cancelall(&p_scux_info_ch->tx_que);
@@ -2968,7 +2968,7 @@ int_t SCUX_SetupDma(scux_info_ch_t * const p_scux_info_ch)
             p_scux_info_ch->dma_rx_ch = R_DMA_Alloc(DMA_ALLOC_CH, NULL);
             if (EERROR == p_scux_info_ch->dma_rx_ch)
             {
-                retval = EMFILE;
+                retval = EMFILE_RBSP;
             }
             else
             {
@@ -4386,8 +4386,8 @@ static void SCUX_DMA_CopyTxEndFlush(scux_info_ch_t * const p_info_ch)
     {
         /* finish send dummy data process, and SCUX stop process */
         retval = R_DMA_Cancel(p_info_ch->dma_tx_ch, &tx_remain_size, &dma_ercd);
-        /* It isn't an error even if error code is EBADF, because it is already stopped. */
-        if ((ESUCCESS != retval) && (EBADF != dma_ercd))
+        /* It isn't an error even if error code is EBADF_RBSP, because it is already stopped. */
+        if ((ESUCCESS != retval) && (EBADF_RBSP != dma_ercd))
         {
             /* NON_NOTICE_ASSERT: DMA operation failed */
         }
@@ -4396,8 +4396,8 @@ static void SCUX_DMA_CopyTxEndFlush(scux_info_ch_t * const p_info_ch)
         p_info_ch->dma_tx_current_size = 0;
 
         retval = R_DMA_Cancel(p_info_ch->dma_rx_ch, &rx_remain_size, &dma_ercd);
-        /* It isn't an error even if error code is EBADF, because it is already stopped. */
-        if ((ESUCCESS != retval) && (EBADF != dma_ercd))
+        /* It isn't an error even if error code is EBADF_RBSP, because it is already stopped. */
+        if ((ESUCCESS != retval) && (EBADF_RBSP != dma_ercd))
         {
             /* NON_NOTICE_ASSERT: DMA operation failed */
         }
@@ -4675,8 +4675,8 @@ static void SCUX_DMA_DirectTxEndFlush(scux_info_ch_t * const p_info_ch)
     {
         /* finish send dummy data process, and SCUX stop process */
         retval = R_DMA_Cancel(p_info_ch->dma_tx_ch, &tx_remain_size, &dma_ercd);
-        /* It isn't an error even if error code is EBADF, because it is already stopped. */
-        if ((ESUCCESS != retval) && (EBADF != dma_ercd))
+        /* It isn't an error even if error code is EBADF_RBSP, because it is already stopped. */
+        if ((ESUCCESS != retval) && (EBADF_RBSP != dma_ercd))
         {
             /* NON_NOTICE_ASSERT: NULL pointer */
         }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_if.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_if.c
@@ -195,10 +195,10 @@ Private functions
 * @param[in]     p_config_data :pointer of several parameters array per channels
 * @param[in,out] p_errno    :pointer of error code
 *                            error code -
-*                            ENOMEM : Making semaphore failed.
-*                            EBUSY  : SCUX driver has been initialized already.
-*                            EFAULT : p_config_data is NULL.
-*                            EFAULT : Internal error is occured.
+*                            ENOMEM_RBSP : Making semaphore failed.
+*                            EBUSY_RBSP  : SCUX driver has been initialized already.
+*                            EFAULT_RBSP : p_config_data is NULL.
+*                            EFAULT_RBSP : Internal error is occured.
 * @retval        other than (-1)
 *                  Operation successful.
 *                EERROR -
@@ -213,11 +213,11 @@ static void *R_SCUX_InitOne(const int_t channel, const void * const p_config_dat
 
     if (NULL == p_info_drv)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else if ((SCUX_CH_0 > channel) || ( SCUX_CH_NUM <= channel))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -225,18 +225,18 @@ static void *R_SCUX_InitOne(const int_t channel, const void * const p_config_dat
 
         if (NULL == p_info_ch)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else if (false != p_info_ch->enabled)
         {
-            ercd = EBUSY;
+            ercd = EBUSY_RBSP;
         }
         else
         {
             if (NULL == p_config_data)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -273,7 +273,7 @@ End of function R_SCUX_InitOne
 * @param[in]     p_driver_instance :which was returned by R_SCUX_Init
 * @param[in,out] p_errno    :pointer of error code
 *                            error code -
-*                            EBADF : Driver status isn't SCUX_DRV_INIT.
+*                            EBADF_RBSP : Driver status isn't SCUX_DRV_INIT.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -294,17 +294,17 @@ static int_t R_SCUX_UnInitOne(const int_t channel, const void* const p_driver_in
     
     if (NULL == p_info_drv)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else if ((SCUX_CH_0 > channel) || ( SCUX_CH_NUM <= channel))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SCUX_DRV_INIT != p_info_drv->drv_stat)
         {
-            ercd = EBADF;
+            ercd = EBADF_RBSP;
         }
         else
         {
@@ -312,11 +312,11 @@ static int_t R_SCUX_UnInitOne(const int_t channel, const void* const p_driver_in
 
             if (NULL == p_info_ch)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else if (false == p_info_ch->enabled)
             {
-                ercd = EBADF;
+                ercd = EBADF_RBSP;
             }
             else
             {
@@ -480,13 +480,13 @@ End of function R_SCUX_UnInit
 *                               is created (not used for serial family driver)
 * @param[in,out] p_errno       :pointer of error code
 *                               error code -
-*                               ENOMEM : Craeaton of IOIF queue is failed.
-*                               ENOENT : Pathname is incorrect length.
-*                               ENOENT : Channel information is NULL.
-*                               EACCES : Setting to flag is other than O_WONLY or O_RDWR
-*                               EMFILE : Allocation of write DMA channel is failed.
-*                               ENOTSUP : Channel is not support.
-*                               EFAULT : Internal error is occured.
+*                               ENOMEM_RBSP : Craeaton of IOIF queue is failed.
+*                               ENOENT_RBSP : Pathname is incorrect length.
+*                               ENOENT_RBSP : Channel information is NULL.
+*                               EACCES_RBSP : Setting to flag is other than O_WRONLY_RBSP or O_RDWR_RBSP
+*                               EMFILE_RBSP : Allocation of write DMA channel is failed.
+*                               ENOTSUP_RBSP : Channel is not support.
+*                               EFAULT_RBSP : Internal error is occured.
 *
 * @retval        Except ERROR -
 *                  Operation successful.
@@ -512,19 +512,19 @@ static int_t R_SCUX_Open(void * const p_driver_instance, const char_t * p_path_n
     /* check driver instance */
     if (NULL == p_driver_instance)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (NULL == p_info_drv)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (SCUX_DRV_INIT != p_info_drv->drv_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -534,13 +534,13 @@ static int_t R_SCUX_Open(void * const p_driver_instance, const char_t * p_path_n
     {
         if (NULL == p_info_drv)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (NULL == p_path_name)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -548,7 +548,7 @@ static int_t R_SCUX_Open(void * const p_driver_instance, const char_t * p_path_n
                 pathname_len = SCUX_StrNLen(p_path_name, MAX_PATH_SEARCH_LEN);
                 if ( (0U == pathname_len) || (MAX_PATH_SEARCH_LEN == pathname_len) )
                 {
-                    ercd = ENOENT;
+                    ercd = ENOENT_RBSP;
                 }
                 else
                 {
@@ -572,7 +572,7 @@ static int_t R_SCUX_Open(void * const p_driver_instance, const char_t * p_path_n
 
                     if (NULL == p_info_ch)
                     {
-                        ercd = ENOENT; /* Pathname not recognised */
+                        ercd = ENOENT_RBSP; /* Pathname not recognised */
                     }
                 }
             }
@@ -583,9 +583,9 @@ static int_t R_SCUX_Open(void * const p_driver_instance, const char_t * p_path_n
     {
         if (ESUCCESS == ercd)
         {
-            if ((O_WRONLY != flags) && (O_RDWR != flags))
+            if ((O_WRONLY_RBSP != flags) && (O_RDWR_RBSP != flags))
             {
-                ercd = EACCES;
+                ercd = EACCES_RBSP;
             }
 
             /* ->MISRA 1.2 It is confirming in advance whether to be NULL or not. */
@@ -597,20 +597,20 @@ static int_t R_SCUX_Open(void * const p_driver_instance, const char_t * p_path_n
             if ((-1) == sem_wait_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
                 if (false == p_info_ch->enabled)
                 {
-                    ercd = ENOTSUP;
+                    ercd = ENOTSUP_RBSP;
                 }
 
                 if (ESUCCESS == ercd)
                 {
                     if (SCUX_CH_INIT != p_info_ch->ch_stat)
                     {
-                        ercd = EBUSY;
+                        ercd = EBUSY_RBSP;
                     }
                 }
 
@@ -624,7 +624,7 @@ static int_t R_SCUX_Open(void * const p_driver_instance, const char_t * p_path_n
             if (osOK != sem_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -655,7 +655,7 @@ End of function R_SCUX_Open
 * @param[in]     p_fd:which was returned by R_SCUX_Init()
 * @param[in,out] p_errno:pointer of error code
 *                        error code -
-*                           EFAULT : Internal error is occured.
+*                           EFAULT_RBSP : Internal error is occured.
 *
 * @retval        ESUCCESS -
 *                  Operation successful.
@@ -673,13 +673,13 @@ static int_t R_SCUX_Close(void * const p_fd, int32_t * const p_errno)
 
     if ((NULL == p_info_ch) || (NULL == p_info_drv))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SCUX_DRV_INIT != p_info_drv->drv_stat)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
 
         if (ESUCCESS == ercd)
@@ -693,14 +693,14 @@ static int_t R_SCUX_Close(void * const p_fd, int32_t * const p_errno)
             if ((-1) == sem_wait_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
 
             if (ESUCCESS == ercd)
             {
                 if (false == p_info_ch->enabled)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
 
                 if (ESUCCESS == ercd)
@@ -708,7 +708,7 @@ static int_t R_SCUX_Close(void * const p_fd, int32_t * const p_errno)
                     if ((SCUX_CH_UNINIT == p_info_ch->ch_stat) ||
                         (SCUX_CH_INIT == p_info_ch->ch_stat))
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
 
@@ -723,7 +723,7 @@ static int_t R_SCUX_Close(void * const p_fd, int32_t * const p_errno)
             if (osOK != sem_ercd)
             {
                 /* set error return value */
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
             }
 
         }
@@ -753,8 +753,8 @@ End of function R_SCUX_Close
 * @param[in]     p_buf  :Data buffer for IOCTL request code.
 * @param[in,out] p_errno:pointer of error code
 *                        error code -
-*                           EINVAL : IOCTL request code is unexpected value.
-*                           EFAULT : Internal error is occured.
+*                           EINVAL_RBSP : IOCTL request code is unexpected value.
+*                           EFAULT_RBSP : Internal error is occured.
 *                           other value : The value depending on IOCTL request code.
 *                                         Refer to the function of scux_ioctl.c for those meanings.
 *
@@ -774,13 +774,13 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
     if ((NULL == p_info_ch) || (NULL == p_info_drv))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SCUX_DRV_INIT != p_info_drv->drv_stat)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
 
         if (ESUCCESS == ercd)
@@ -796,7 +796,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                 if ((-1) == sem_wait_ercd)
                 {
                     /* set error return value */
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
 
@@ -804,7 +804,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
             {
                 if (false == p_info_ch->enabled)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
 
                 if (ESUCCESS == ercd)
@@ -812,7 +812,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                     if ((SCUX_CH_UNINIT == p_info_ch->ch_stat) ||
                         (SCUX_CH_INIT == p_info_ch->ch_stat))
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
 
@@ -825,7 +825,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                 if (osOK != sem_ercd)
                 {
                     /* set error return value */
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
 
@@ -844,13 +844,13 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             if (SCUX_CH_STOP != p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
                             }
                             else
                             {
@@ -863,7 +863,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -879,21 +879,21 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             /* check p_Buf */
                             if (NULL == p_buf)
                             {
-                                ercd = EFAULT;
+                                ercd = EFAULT_RBSP;
                             }
                             else
                             {
                                 core_util_critical_section_enter();
                                 if (SCUX_CH_STOP == p_info_ch->ch_stat)
                                 {
-                                    ercd = EBUSY;
+                                    ercd = EBUSY_RBSP;
                                 }
 
                                 /* The mesure to MISRA 1.1 , SEC P1.1.1 */
@@ -918,7 +918,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -935,14 +935,14 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             core_util_critical_section_enter();
                             if (SCUX_CH_STOP == p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
 
                                 core_util_critical_section_exit();
                             }
@@ -958,7 +958,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -974,19 +974,19 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             if (SCUX_CH_STOP != p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
                             }
                             else
                             {
                                 if (NULL == p_buf)
                                 {
-                                    ercd = EFAULT;
+                                    ercd = EFAULT_RBSP;
                                 }
                                 else
                                 {
@@ -1000,7 +1000,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -1016,19 +1016,19 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             if (SCUX_CH_STOP != p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
                             }
                             else
                             {
                                 if (NULL == p_buf)
                                 {
-                                    ercd = EFAULT;
+                                    ercd = EFAULT_RBSP;
                                 }
                                 else
                                 {
@@ -1042,7 +1042,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -1058,19 +1058,19 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             if (SCUX_CH_STOP != p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
                             }
                             else
                             {
                                 if (NULL == p_buf)
                                 {
-                                    ercd = EFAULT;
+                                    ercd = EFAULT_RBSP;
                                 }
                                 else
                                 {
@@ -1084,7 +1084,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -1100,19 +1100,19 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             if (SCUX_CH_STOP != p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
                             }
                             else
                             {
                                 if (NULL == p_buf)
                                 {
-                                    ercd = EFAULT;
+                                    ercd = EFAULT_RBSP;
                                 }
                                 else
                                 {
@@ -1126,7 +1126,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -1142,19 +1142,19 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             if (SCUX_CH_STOP != p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
                             }
                             else
                             {
                                 if (NULL == p_buf)
                                 {
-                                    ercd = EFAULT;
+                                    ercd = EFAULT_RBSP;
                                 }
                                 else
                                 {
@@ -1168,7 +1168,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -1177,7 +1177,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1190,7 +1190,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1203,7 +1203,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1216,7 +1216,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1229,7 +1229,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1242,7 +1242,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1262,19 +1262,19 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if ((-1) == sem_wait_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
                             if (SCUX_CH_STOP != p_info_ch->ch_stat)
                             {
-                                ercd = EBUSY;
+                                ercd = EBUSY_RBSP;
                             }
                             else
                             {
                                 if (NULL == p_buf)
                                 {
-                                    ercd = EFAULT;
+                                    ercd = EFAULT_RBSP;
                                 }
                                 else
                                 {
@@ -1288,7 +1288,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                         if (osOK != sem_ercd)
                         {
                             /* set error return value */
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
 
                     break;
@@ -1297,7 +1297,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1310,7 +1310,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1323,7 +1323,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1336,7 +1336,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1349,7 +1349,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
 
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -1359,7 +1359,7 @@ static int_t R_SCUX_Ioctl(void * const p_fd, const int_t request, void * const p
                     break;
 
                     default:
-                        ercd = EINVAL;
+                        ercd = EINVAL_RBSP;
                     break;
                 }
             }
@@ -1390,10 +1390,10 @@ End of function R_SCUX_Ioctl
 * @param[in]     p_aio  :aio control block.
 * @param[in,out] p_errno:pointer of error code
 *                               error code -
-*                               EBADF : Channel status isn't SCUX_CH_STOP or SCUX_CH_STOP_WAIT.
-*                               EINVAL : p_fd is NULL.
-*                               EINVAL : write size is 0.
-*                               EFAULT : Internal error is occured.
+*                               EBADF_RBSP : Channel status isn't SCUX_CH_STOP or SCUX_CH_STOP_WAIT.
+*                               EINVAL_RBSP : p_fd is NULL.
+*                               EINVAL_RBSP : write size is 0.
+*                               EFAULT_RBSP : Internal error is occured.
 *
 * @retval        ESUCCESS -
 *                  Operation successful.
@@ -1411,20 +1411,20 @@ static int_t R_SCUX_WriteAsync(void * const p_fd, AIOCB * const p_aio, int32_t *
 
     if ((NULL == p_info_ch) || (NULL == p_aio) || (NULL == p_info_drv))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (0U == p_aio->aio_nbytes)
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
 
         if (ESUCCESS == ercd)
         {
             if (SCUX_DRV_INIT != p_info_drv->drv_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
 
@@ -1439,13 +1439,13 @@ static int_t R_SCUX_WriteAsync(void * const p_fd, AIOCB * const p_aio, int32_t *
             if ((-1) == sem_wait_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
                 if (false == p_info_ch->enabled)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
 
@@ -1465,11 +1465,11 @@ static int_t R_SCUX_WriteAsync(void * const p_fd, AIOCB * const p_aio, int32_t *
                         case SCUX_CH_UNINIT :
                             /* fall through */
                         case SCUX_CH_INIT :
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         break;
 
                         case SCUX_CH_STOP :
-                            ercd = EBADF;
+                            ercd = EBADF_RBSP;
                         break;
 
                         case SCUX_CH_TRANS_IDLE :
@@ -1494,11 +1494,11 @@ static int_t R_SCUX_WriteAsync(void * const p_fd, AIOCB * const p_aio, int32_t *
                         case SCUX_CH_STOP_WAIT :
                             /* fall through */
                         case SCUX_CH_STOP_WAIT_IDLE :
-                            ercd = EBADF;
+                            ercd = EBADF_RBSP;
                         break;
 
                         default :
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         break;
                     }
                 }
@@ -1510,7 +1510,7 @@ static int_t R_SCUX_WriteAsync(void * const p_fd, AIOCB * const p_aio, int32_t *
             if (osOK != sem_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -1538,11 +1538,11 @@ End of function R_SCUX_WriteAsync
 * @param[in]     p_aio  :aio control block.
 * @param[in,out] p_errno:pointer of error code
 *                               error code -
-*                               EBADF : Channel status isn't SCUX_CH_STOP or SCUX_CH_STOP_WAIT.
-*                               EINVAL : read size is 0.
-*                               EACCES : Request for write only mode channel.
-*                               EACCES : Route setting is unexpected.
-*                               EFAULT : Internal error is occured.
+*                               EBADF_RBSP : Channel status isn't SCUX_CH_STOP or SCUX_CH_STOP_WAIT.
+*                               EINVAL_RBSP : read size is 0.
+*                               EACCES_RBSP : Request for write only mode channel.
+*                               EACCES_RBSP : Route setting is unexpected.
+*                               EFAULT_RBSP : Internal error is occured.
 *
 * @retval        ESUCCESS -
 *                  Operation successful.
@@ -1560,20 +1560,20 @@ static int_t R_SCUX_ReadAsync(void * const p_fd, AIOCB * const p_aio, int32_t * 
 
     if ((NULL == p_info_ch) || (NULL == p_info_drv) || (NULL == p_aio))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (0U == p_aio->aio_nbytes)
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
 
         if (ESUCCESS == ercd)
         {
             if (SCUX_DRV_INIT != p_info_drv->drv_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
 
@@ -1588,21 +1588,21 @@ static int_t R_SCUX_ReadAsync(void * const p_fd, AIOCB * const p_aio, int32_t * 
             if ((-1) == sem_wait_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
                 if (false == p_info_ch->enabled)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
 
             if (ESUCCESS == ercd)
             {
-                if (O_WRONLY == (p_info_ch->open_flags & O_ACCMODE))
+                if (O_WRONLY_RBSP == (p_info_ch->open_flags & O_ACCMODE_RBSP))
                 {
-                    ercd = EACCES;
+                    ercd = EACCES_RBSP;
                 }
             }
 
@@ -1611,7 +1611,7 @@ static int_t R_SCUX_ReadAsync(void * const p_fd, AIOCB * const p_aio, int32_t * 
 
                 if (SCUX_ROUTE_MEM_TO_MEM != (p_info_ch->route_set & SCUX_GET_ROUTE_MASK))
                 {
-                    ercd = EACCES;
+                    ercd = EACCES_RBSP;
                 }
 
                 if (ESUCCESS == ercd)
@@ -1630,11 +1630,11 @@ static int_t R_SCUX_ReadAsync(void * const p_fd, AIOCB * const p_aio, int32_t * 
                             case SCUX_CH_UNINIT :
                                 /* fall through */
                             case SCUX_CH_INIT :
-                                ercd = EFAULT;
+                                ercd = EFAULT_RBSP;
                             break;
 
                             case SCUX_CH_STOP :
-                                ercd = EBADF;
+                                ercd = EBADF_RBSP;
                             break;
 
                             case SCUX_CH_TRANS_IDLE :
@@ -1660,7 +1660,7 @@ static int_t R_SCUX_ReadAsync(void * const p_fd, AIOCB * const p_aio, int32_t * 
                             break;
 
                             default :
-                                ercd = EFAULT;
+                                ercd = EFAULT_RBSP;
                             break;
                         }
                     }
@@ -1673,7 +1673,7 @@ static int_t R_SCUX_ReadAsync(void * const p_fd, AIOCB * const p_aio, int32_t * 
             if (osOK != sem_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -1702,7 +1702,7 @@ End of function R_SCUX_ReadAsync
 * @param[in]     p_aio  :aio control block.
 * @param[in,out] p_errno:pointer of error code
 *                               error code -
-*                               EFAULT : Internal error is occured.
+*                               EFAULT_RBSP : Internal error is occured.
 *
 * @retval        ESUCCESS -
 *                  Operation successful.
@@ -1720,13 +1720,13 @@ static int_t R_SCUX_Cancel(void * const p_fd, AIOCB * const p_aio, int32_t * con
 
     if ((NULL == p_info_ch) || (NULL == p_info_drv))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SCUX_DRV_INIT != p_info_drv->drv_stat)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
 
         if (ESUCCESS == ercd)
@@ -1740,14 +1740,14 @@ static int_t R_SCUX_Cancel(void * const p_fd, AIOCB * const p_aio, int32_t * con
             if ((-1) == sem_wait_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
 
             if (ESUCCESS == ercd)
             {
                 if (false == p_info_ch->enabled)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
 
                 if (ESUCCESS == ercd)
@@ -1756,14 +1756,14 @@ static int_t R_SCUX_Cancel(void * const p_fd, AIOCB * const p_aio, int32_t * con
                         (SCUX_CH_UNINIT == p_info_ch->ch_stat))
                     {
                         /* It should not becomde status */
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                     else if ((SCUX_CH_STOP_WAIT == p_info_ch->ch_stat) ||
                               (SCUX_CH_STOP_WAIT_IDLE == p_info_ch->ch_stat) ||
                               (SCUX_CH_STOP == p_info_ch->ch_stat))
                     {
                         /* busy error on flush waiting */
-                        ercd = EBADF;
+                        ercd = EBADF_RBSP;
                     }
                     else
                     {
@@ -1797,7 +1797,7 @@ static int_t R_SCUX_Cancel(void * const p_fd, AIOCB * const p_aio, int32_t * con
             if (osOK != sem_ercd)
             {
                 /* set error return value */
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_int.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_int.c
@@ -307,12 +307,12 @@ static void R_SCUX_FdiHandlerProcess(const scux_ch_num_t channel)
         if ((p_info_ch->p_scux_reg->p_ffd_reg->DEVCR_FFD0_0 & DEVCR_FFD0_DEVCOL_MASK) != 0)
         {
             /* critical error (over lap) */
-            ercd = EIO;
+            ercd = EIO_RBSP;
         }
         else
         {
             /* be returned error (FFD under flow, over flow) */
-            ercd = EOVERFLOW;
+            ercd = EOVERFLOW_RBSP;
         }
 
         p_info_ch->p_scux_reg->p_ffd_reg->DEVCR_FFD0_0 &= ~(DEVCR_FFD0_DEVCUF_SET |
@@ -438,12 +438,12 @@ static void R_SCUX_FuiHandlerProcess(const scux_ch_num_t channel)
         if ((p_info_ch->p_scux_reg->p_ffu_reg->UEVCR_FFU0_0 & UEVCR_FFU0_UEVCOL_MASK) != 0)
         {
             /* critical error (over lap) */
-            ercd = EIO;
+            ercd = EIO_RBSP;
         }
         else
         {
             /* be returned error (FFU under flow, over flow) */
-            ercd = EOVERFLOW;
+            ercd = EOVERFLOW_RBSP;
         }
 
         p_info_ch->p_scux_reg->p_ffu_reg->UEVCR_FFU0_0 &= ~(UEVCR_FFU0_UEVCUF_SET |
@@ -668,7 +668,7 @@ static void R_SCUX_AiHandlerProcess(const uint32_t src_channel)
                     p_info_ch->p_scux_reg->p_src_reg->SEVCR0_2SRC0_0 &= ~(SEVCR_2SRC0_EVCUF_SET |
                                                                           SEVCR_2SRC0_EVCOF_SET);
                     /* be returned error (FFU under flow, over flow) */
-                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW);
+                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW_RBSP);
                 }
             }
 
@@ -685,7 +685,7 @@ static void R_SCUX_AiHandlerProcess(const uint32_t src_channel)
                     p_info_ch->p_scux_reg->p_src_reg->SEVCR1_2SRC0_0 &= ~(SEVCR_2SRC0_EVCUF_SET |
                                                                           SEVCR_2SRC0_EVCOF_SET);
                     /* be returned error (FFU under flow, over flow) */
-                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW);
+                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW_RBSP);
                 }
             }
         }
@@ -711,7 +711,7 @@ static void R_SCUX_AiHandlerProcess(const uint32_t src_channel)
                     p_info_ch->p_scux_reg->p_src_reg->SEVCR0_2SRC0_0 &= ~(SEVCR_2SRC0_EVCUF_SET |
                                                                           SEVCR_2SRC0_EVCOF_SET);
                     /* be returned error (FFU under flow, over flow) */
-                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW);
+                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW_RBSP);
                 }
             }
 
@@ -728,7 +728,7 @@ static void R_SCUX_AiHandlerProcess(const uint32_t src_channel)
                     p_info_ch->p_scux_reg->p_src_reg->SEVCR1_2SRC0_0 &= ~(SEVCR_2SRC0_EVCUF_SET |
                                                                           SEVCR_2SRC0_EVCOF_SET);
                     /* be returned error (FFU under flow, over flow) */
-                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW);
+                    R_SCUX_ErrHandlerProcess(p_info_ch, EOVERFLOW_RBSP);
                 }
             }
         }
@@ -769,8 +769,8 @@ static void R_SCUX_ErrHandlerProcess(scux_info_ch_t * const p_scux_info_ch, cons
     else
     {
         retval = R_DMA_Cancel(p_scux_info_ch->dma_tx_ch, &tx_remain_size, &dma_retval);
-        /* DMA stop check, (when dma_retval is EBADF, DMA stopped already) */
-        if ((ESUCCESS != retval) && (EBADF != dma_retval))
+        /* DMA stop check, (when dma_retval is EBADF_RBSP, DMA stopped already) */
+        if ((ESUCCESS != retval) && (EBADF_RBSP != dma_retval))
         {
             /* NON_NOTICE_ASSERT: NULL pointer */
         }
@@ -784,8 +784,8 @@ static void R_SCUX_ErrHandlerProcess(scux_info_ch_t * const p_scux_info_ch, cons
         {
             retval = R_DMA_Cancel(p_scux_info_ch->dma_rx_ch, &rx_remain_size, &dma_retval);
 
-            /* DMA stop check, (when dma_retval is EBADF, DMA stopped already) */
-            if ((ESUCCESS != retval) && (EBADF != dma_retval))
+            /* DMA stop check, (when dma_retval is EBADF_RBSP, DMA stopped already) */
+            if ((ESUCCESS != retval) && (EBADF_RBSP != dma_retval))
             {
                 /* NON_NOTICE_ASSERT: NULL pointer */
             }
@@ -830,7 +830,7 @@ static void R_SCUX_ErrHandlerProcess(scux_info_ch_t * const p_scux_info_ch, cons
                 }
                 else
                 {
-                    p_scux_info_ch->p_tx_next_aio->aio_return = ECANCELED;
+                    p_scux_info_ch->p_tx_next_aio->aio_return = ECANCELED_RBSP;
                 }
                 ahf_complete(&p_scux_info_ch->tx_que, p_scux_info_ch->p_tx_next_aio);
             }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_ioctl.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/scux/scux_ioctl.c
@@ -57,15 +57,15 @@ Private global driver management information
 * @param[in]     channel:SCUX channel number.
 * @param[in]     p_scux_addr_param:address parameter.
 * @retval        ESUCCESS : Operation successful.
-*                EACCES : DVU setup isn't carried out when using DVU.
-*                EACCES : MIX setup isn't carried out when using MIX.
-*                EACCES : SSIF setup isn't carried out when using SSIF.
-*                EACCES : SSIF channel is already used.
-*                EACCES : When use MIX, it is a setup which does not agree in a route setup.
-*                EBUSY : It has already transmitted.
-*                EMFILE : Allocate DMA ch for read is failed.
-*                EPERM : Transfer parameter is unexpected.
-*                EFAULT : Internal error is occured.
+*                EACCES_RBSP : DVU setup isn't carried out when using DVU.
+*                EACCES_RBSP : MIX setup isn't carried out when using MIX.
+*                EACCES_RBSP : SSIF setup isn't carried out when using SSIF.
+*                EACCES_RBSP : SSIF channel is already used.
+*                EACCES_RBSP : When use MIX, it is a setup which does not agree in a route setup.
+*                EBUSY_RBSP : It has already transmitted.
+*                EMFILE_RBSP : Allocate DMA ch for read is failed.
+*                EPERM_RBSP : Transfer parameter is unexpected.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 #if(1) /* mbed */
@@ -92,7 +92,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
     }
     if ((NULL == p_info_drv) || (NULL == p_info_ch))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -106,7 +106,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
             if ((-1) == sem_wait_ercd)
             {
                 /* set semaphore error */
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
         }
 
@@ -137,7 +137,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -154,7 +154,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -169,7 +169,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -184,7 +184,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -201,7 +201,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -219,7 +219,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -234,7 +234,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -249,7 +249,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -267,7 +267,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -284,7 +284,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -299,7 +299,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -314,7 +314,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -331,7 +331,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -349,7 +349,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -364,7 +364,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -379,7 +379,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -397,7 +397,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -415,7 +415,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -433,7 +433,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -451,7 +451,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -469,7 +469,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -486,7 +486,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -501,7 +501,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -516,7 +516,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -533,7 +533,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -551,7 +551,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -566,7 +566,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -581,7 +581,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -599,7 +599,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -616,7 +616,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -631,7 +631,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -646,7 +646,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -663,7 +663,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -681,7 +681,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -696,7 +696,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -711,7 +711,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -729,7 +729,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -746,7 +746,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -761,7 +761,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -776,7 +776,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -793,7 +793,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -811,7 +811,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -826,7 +826,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -841,7 +841,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -859,7 +859,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -876,7 +876,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -891,7 +891,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -906,7 +906,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -923,7 +923,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -941,7 +941,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -956,7 +956,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -971,7 +971,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -1052,7 +1052,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
                 if (osOK != sem_ercd)
                 {
                     /* set semaphore error */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                     p_info_ch->ch_stat = SCUX_CH_STOP;
                 }
             }
@@ -1066,7 +1066,7 @@ int_t SCUX_IoctlTransStart(const int_t channel)
             if (osOK != sem_ercd)
             {
                 /* set semaphore error */
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
                 p_info_ch->ch_stat = SCUX_CH_STOP;
             }
         }
@@ -1093,7 +1093,7 @@ End of function SCUX_IoctlTransStart
 * @param[in]     channel:SCUX channel number.
 * @param[in]     (*callback)(void):callback function pointer.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlFlushStop(const int_t channel, void (* const callback)(int_t))
@@ -1103,7 +1103,7 @@ int_t SCUX_IoctlFlushStop(const int_t channel, void (* const callback)(int_t))
 
     if (NULL == p_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1195,7 +1195,7 @@ End of function SCUX_IoctlFlushStop
 *
 * @param[in]     channel:SCUX channel number.
 * @retval        ESUCCESS : Operation successful.
-*                EFAULT : Internal error is occured.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlClearStop(const int_t channel)
@@ -1214,7 +1214,7 @@ int_t SCUX_IoctlClearStop(const int_t channel)
     scux_info_ch_t * const p_info_ch = SCUX_GetDrvChInfo(channel);
     if (NULL == p_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
         core_util_critical_section_exit();
     }
     else
@@ -1223,10 +1223,10 @@ int_t SCUX_IoctlClearStop(const int_t channel)
         {
             /* memory to memory route */
             dma_retval = R_DMA_Cancel(p_info_ch->dma_tx_ch, &tx_remain_size, &dma_ercd);
-            /* DMA stop check, (when dma_ercd is EBADF, DMA stopped already) */
-            if ((ESUCCESS != dma_retval) && (EBADF != dma_ercd))
+            /* DMA stop check, (when dma_ercd is EBADF_RBSP, DMA stopped already) */
+            if ((ESUCCESS != dma_retval) && (EBADF_RBSP != dma_ercd))
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -1235,10 +1235,10 @@ int_t SCUX_IoctlClearStop(const int_t channel)
             }
 
             dma_retval = R_DMA_Cancel(p_info_ch->dma_rx_ch, &rx_remain_size, &dma_ercd);
-            /* DMA stop check, (when dma_ercd is EBADF, DMA stopped already) */
-            if ((ESUCCESS != dma_retval) && (EBADF != dma_ercd))
+            /* DMA stop check, (when dma_ercd is EBADF_RBSP, DMA stopped already) */
+            if ((ESUCCESS != dma_retval) && (EBADF_RBSP != dma_ercd))
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -1248,7 +1248,7 @@ int_t SCUX_IoctlClearStop(const int_t channel)
                 dma_retval = R_DMA_Free(p_info_ch->dma_rx_ch, NULL);
                 if (ESUCCESS != dma_retval)
                 {
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
             }
 
@@ -1279,10 +1279,10 @@ int_t SCUX_IoctlClearStop(const int_t channel)
         {
             /* SSIF direct route */
             dma_retval = R_DMA_Cancel(p_info_ch->dma_tx_ch, &tx_remain_size, &dma_ercd);
-            /* DMA stop check, (when dma_ercd is EBADF, DMA stopped already) */
-            if ((ESUCCESS != dma_retval) && (EBADF != dma_ercd))
+            /* DMA stop check, (when dma_ercd is EBADF_RBSP, DMA stopped already) */
+            if ((ESUCCESS != dma_retval) && (EBADF_RBSP != dma_ercd))
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -1304,7 +1304,7 @@ int_t SCUX_IoctlClearStop(const int_t channel)
                     /* return next aio request */
                     if (NULL != p_info_ch->p_tx_next_aio)
                     {
-                        p_info_ch->p_tx_next_aio->aio_return = ECANCELED;
+                        p_info_ch->p_tx_next_aio->aio_return = ECANCELED_RBSP;
                         ahf_complete(&p_info_ch->tx_que, p_info_ch->p_tx_next_aio);
                     }
                 }
@@ -1331,7 +1331,7 @@ int_t SCUX_IoctlClearStop(const int_t channel)
                         /* in case of the next request is acquired */
                         if (NULL != p_info_ch->p_tx_next_aio)
                         {
-                            p_info_ch->p_tx_next_aio->aio_return = ECANCELED;
+                            p_info_ch->p_tx_next_aio->aio_return = ECANCELED_RBSP;
                             ahf_complete(&p_info_ch->tx_que, p_info_ch->p_tx_next_aio);
                         }
                     }
@@ -1362,7 +1362,7 @@ int_t SCUX_IoctlClearStop(const int_t channel)
 
             if ((SCUX_CH_STOP_WAIT == old_stat) || (SCUX_CH_STOP_WAIT_IDLE == old_stat))
             {
-                p_info_ch->p_flush_callback(ECANCELED);
+                p_info_ch->p_flush_callback(ECANCELED_RBSP);
                 p_info_ch->p_flush_callback = NULL;
             }
         }
@@ -1420,8 +1420,8 @@ End of function SCUX_IoctlSetRoute
 * @param[in]     channel:SCUX channel number.
 * @param[in]     *p_pin_clk_param:clock source parameter.
 * @retval        ESUCCESS:Operation successful.
-*                EPERM:Parameter is unexpected value.
-*                EFAULT:Internal error is occured.
+*                EPERM_RBSP:Parameter is unexpected value.
+*                EFAULT_RBSP:Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const p_pin_clk_param)
@@ -1435,7 +1435,7 @@ int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const
 
     if ((NULL == p_info_drv) || (NULL == p_info_ch) || (NULL == p_pin_clk_param))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1445,7 +1445,7 @@ int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const
             p_ssif_ch = SCUX_GetSsifChInfo((int_t)p_pin_clk_param->ssif_ch_num);
             if (NULL == p_ssif_ch)
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -1456,7 +1456,7 @@ int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const
                 if ((-1) == sem_wait_ercd)
                 {
                     /* set semaphore error */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
                 else
                 {
@@ -1467,7 +1467,7 @@ int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const
                     }
                     else
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 }
                 sem_ercd = osSemaphoreRelease(p_ssif_ch->sem_ch_scux_ssif_access);
@@ -1475,7 +1475,7 @@ int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const
                 if (osOK != sem_ercd)
                 {
                     /* set semaphore error */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
 
                 if (ESUCCESS == retval)
@@ -1487,7 +1487,7 @@ int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -1508,14 +1508,14 @@ int_t SCUX_IoctlSetPinClk(const int_t channel, const scux_ssif_pin_clk_t * const
                     if (osOK != sem_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                 }
             }
         }
         else
         {
-            retval = EPERM;
+            retval = EPERM_RBSP;
         }
     }
 
@@ -1535,7 +1535,7 @@ End of function SCUX_IoctlSetPinClk
 * @param[in]     channel:SCUX channel number.
 * @param[in]     *p_pin_mode_param:synchronous setting parameter.
 * @retval        ESUCCESS:Operation successful.
-*                EPERM:Parameter is unexpected value.
+*                EPERM_RBSP:Parameter is unexpected value.
 *                EFAUT:Internal error is occured.
 ******************************************************************************/
 
@@ -1553,7 +1553,7 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
 
     if ((NULL == p_info_drv) || (NULL == p_info_ch) || (NULL == p_pin_mode_param))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1563,7 +1563,7 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
             p_ssif_ch = SCUX_GetSsifChInfo((int_t)p_pin_mode_param->ssif_ch_num);
             if (NULL == p_ssif_ch)
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -1574,7 +1574,7 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
                 if ((-1) == sem_wait_ercd)
                 {
                     /* set semaphore error */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
                 else
                 {
@@ -1585,7 +1585,7 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
                     }
                     else
                     {
-                        retval = EPERM;
+                        retval = EPERM_RBSP;
                     }
                 }
                 sem_ercd = osSemaphoreRelease(p_ssif_ch->sem_ch_scux_ssif_access);
@@ -1593,7 +1593,7 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
                 if (osOK != sem_ercd)
                 {
                     /* set semaphore error */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
 
                 if (ESUCCESS == retval)
@@ -1605,7 +1605,7 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
                     if ((-1) == sem_wait_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                     else
                     {
@@ -1643,7 +1643,7 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
 #endif /* mbed */
                                 default :
                                     /* SCUX channel is 6 oe more */
-                                    retval = EPERM;
+                                    retval = EPERM_RBSP;
                                 break;
                             }
 
@@ -1664,14 +1664,14 @@ int_t SCUX_IoctlSetPinMode(const int_t channel, const scux_ssif_pin_mode_t * con
                     if (osOK != sem_ercd)
                     {
                         /* set semaphore error */
-                        retval = EFAULT;
+                        retval = EFAULT_RBSP;
                     }
                 }
             }
         }
         else
         {
-            retval = EPERM;
+            retval = EPERM_RBSP;
         }
     }
 
@@ -1801,8 +1801,8 @@ End of function SCUX_IoctlSetDvuCfg
 * @param[in]     channel:SCUX channel number.
 * @param[in]     *p_dvu_param:Digital volume parameter.
 * @retval        ESUCCESS:Operation successful.
-*                EPERM:Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EPERM_RBSP:Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetDvuDigiVol(const int_t channel, const scux_dvu_digi_vol_t * const p_digi_vol_param)
@@ -1813,7 +1813,7 @@ int_t SCUX_IoctlSetDvuDigiVol(const int_t channel, const scux_dvu_digi_vol_t * c
 
     if ((NULL == p_info_ch) || (NULL == p_digi_vol_param))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1833,7 +1833,7 @@ int_t SCUX_IoctlSetDvuDigiVol(const int_t channel, const scux_dvu_digi_vol_t * c
         {
             if (SCUX_MAX_DIGITAL_VOLUME < p_info_ch->dvu_cfg.dvu_digi_vol.digi_vol[audio_ch])
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1871,8 +1871,8 @@ End of function SCUX_IoctlSetDvuDigiVol
 * @param[in]     channel:SCUX channel number.
 * @param[in]     *p_dvu_param:Digital volume parameter.
 * @retval        ESUCCESS:Operation successful.
-*                EPERM:Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EPERM_RBSP:Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetDvuRampVol(const int_t channel, const scux_dvu_ramp_vol_t * const p_ramp_vol_param)
@@ -1883,7 +1883,7 @@ int_t SCUX_IoctlSetDvuRampVol(const int_t channel, const scux_dvu_ramp_vol_t * c
 
     if ((NULL == p_info_ch) || (NULL == p_ramp_vol_param))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -1902,7 +1902,7 @@ int_t SCUX_IoctlSetDvuRampVol(const int_t channel, const scux_dvu_ramp_vol_t * c
         if ((p_info_ch->dvu_cfg.dvu_ramp_vol.down_period <= SCUX_DVU_TIME_MIN) ||
             (p_info_ch->dvu_cfg.dvu_ramp_vol.down_period >= SCUX_DVU_TIME_MAX))
         {
-               retval = EPERM;
+               retval = EPERM_RBSP;
         }
 
         if (ESUCCESS == retval)
@@ -1911,7 +1911,7 @@ int_t SCUX_IoctlSetDvuRampVol(const int_t channel, const scux_dvu_ramp_vol_t * c
             if ((p_info_ch->dvu_cfg.dvu_ramp_vol.up_period <= SCUX_DVU_TIME_MIN) ||
                 (p_info_ch->dvu_cfg.dvu_ramp_vol.up_period >= SCUX_DVU_TIME_MAX))
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1920,7 +1920,7 @@ int_t SCUX_IoctlSetDvuRampVol(const int_t channel, const scux_dvu_ramp_vol_t * c
             /* check ramp volume */
             if (SCUX_MAX_RAMP_VOLUME < p_info_ch->dvu_cfg.dvu_ramp_vol.ramp_vol)
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1929,7 +1929,7 @@ int_t SCUX_IoctlSetDvuRampVol(const int_t channel, const scux_dvu_ramp_vol_t * c
             /* check wait time */
             if (SCUX_MAX_WAIT_TIME < p_info_ch->dvu_cfg.dvu_ramp_vol.ramp_wait_time)
             {
-                retval = EPERM;
+                retval = EPERM_RBSP;
             }
         }
 
@@ -1970,8 +1970,8 @@ End of function SCUX_IoctlSetDvuRampVol
 * @param[in]     channel:SCUX channel number.
 * @param[in]     *p_zc_mute_param:zerocross mute parameter.
 * @retval        ESUCCESS:Operation successful.
-*                EPERM:Parameter is unexpected value.
-*                EPERM:Rewrite callback pointer while waiting zerocross.
+*                EPERM_RBSP:Parameter is unexpected value.
+*                EPERM_RBSP:Rewrite callback pointer while waiting zerocross.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetDvuZerocrossMute(const int_t channel, const scux_zc_mute_t * const p_zc_mute_param)
@@ -1982,7 +1982,7 @@ int_t SCUX_IoctlSetDvuZerocrossMute(const int_t channel, const scux_zc_mute_t * 
 
     if ((NULL == p_info_ch) || (NULL == p_zc_mute_param))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -2024,8 +2024,8 @@ End of function SCUX_IoctlSetDvuZerocrossMute
 * @param[in]     channel:SCUX channel number.
 * @param[in]     audio_channel:Audio channel number.
 * @retval        ESUCCESS:Operation successful.
-*                EPERM:Parameter is unexpected value.
-*                EFAULT : Internal error is occured.
+*                EPERM_RBSP:Parameter is unexpected value.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetStopMute(const int_t channel, const uint32_t audio_channel)
@@ -2035,13 +2035,13 @@ int_t SCUX_IoctlSetStopMute(const int_t channel, const uint32_t audio_channel)
 
     if (NULL == p_info_ch)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
         if (audio_channel >= (uint32_t)p_info_ch->src_cfg.use_ch)
         {
-            retval = EPERM;
+            retval = EPERM_RBSP;
         }
 
         if (ESUCCESS == retval)
@@ -2073,8 +2073,8 @@ End of function SCUX_IoctlSetStopMute
 *
 * @param[in]     *p_mix_param:MIX parameter.
 * @retval        ESUCCESS : Operation successful.
-*                EPERM : Transfer parameter is unexpected.
-*                EFAULT : Internal error is occured.
+*                EPERM_RBSP : Transfer parameter is unexpected.
+*                EFAULT_RBSP : Internal error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetMixCfg(const scux_mix_cfg_t * const p_mix_param)
@@ -2086,7 +2086,7 @@ int_t SCUX_IoctlSetMixCfg(const scux_mix_cfg_t * const p_mix_param)
 
     if ((NULL == p_info_drv) || (NULL == p_mix_param))
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -2112,7 +2112,7 @@ int_t SCUX_IoctlSetMixCfg(const scux_mix_cfg_t * const p_mix_param)
                 /* check ramp volume */
                 if (SCUX_MAX_RAMP_VOLUME < p_info_drv->shared_info.mix_vol[scux_ch])
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
             }
         }
@@ -2155,8 +2155,8 @@ End of function SCUX_IoctlSetMixCfg
 * @param[in]     channel:SCUX channel number.
 * @param[in]     mix_vol:MIX volume.
 * @retval        ESUCCESS : Operation successful.
-*                EPERM : Transfer parameter is unexpected.
-*                EFAULT: Internel error si occured.
+*                EPERM_RBSP : Transfer parameter is unexpected.
+*                EFAULT_RBSP: Internel error si occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetMixVol(const int_t channel, const uint32_t mix_vol)
@@ -2168,7 +2168,7 @@ int_t SCUX_IoctlSetMixVol(const int_t channel, const uint32_t mix_vol)
 
     if (NULL == p_info_drv)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -2181,7 +2181,7 @@ int_t SCUX_IoctlSetMixVol(const int_t channel, const uint32_t mix_vol)
             if ((-1) == sem_wait_ercd)
             {
                 /* set semaphore error */
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
         }
 
@@ -2197,7 +2197,7 @@ int_t SCUX_IoctlSetMixVol(const int_t channel, const uint32_t mix_vol)
                 /* check ramp volume */
                 if (SCUX_MAX_RAMP_VOLUME < p_info_drv->shared_info.mix_vol[channel])
                 {
-                    retval = EPERM;
+                    retval = EPERM_RBSP;
                 }
                 else
                 {
@@ -2216,7 +2216,7 @@ int_t SCUX_IoctlSetMixVol(const int_t channel, const uint32_t mix_vol)
             if (osOK != sem_ercd)
             {
                 /* set semaphore error */
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
         }
     }
@@ -2237,9 +2237,9 @@ End of function SCUX_IoctlSetMixVol
 * @param[in]     channel:SCUX channel number.
 * @param[in]     p_ssif_param:SSIF parameter.
 * @retval        ESUCCESS : Operation successful.
-*                EBADF : SSIF channel has already used on other SCUX channel.
-*                EPERM : Transfer parameter is unexpected.
-*                EFAULT: Internel error is occured.
+*                EBADF_RBSP : SSIF channel has already used on other SCUX channel.
+*                EPERM_RBSP : Transfer parameter is unexpected.
+*                EFAULT_RBSP: Internel error is occured.
 ******************************************************************************/
 
 int_t SCUX_IoctlSetSsifCfg(const scux_ssif_cfg_t * const p_ssif_param)
@@ -2251,7 +2251,7 @@ int_t SCUX_IoctlSetSsifCfg(const scux_ssif_cfg_t * const p_ssif_param)
 
     if (NULL == p_ssif_param)
     {
-        retval = EFAULT;
+        retval = EFAULT_RBSP;
     }
     else
     {
@@ -2260,7 +2260,7 @@ int_t SCUX_IoctlSetSsifCfg(const scux_ssif_cfg_t * const p_ssif_param)
             p_ssif_ch = SCUX_GetSsifChInfo((int_t)p_ssif_param->ssif_ch_num);
             if (NULL == p_ssif_ch)
             {
-                retval = EFAULT;
+                retval = EFAULT_RBSP;
             }
             else
             {
@@ -2271,13 +2271,13 @@ int_t SCUX_IoctlSetSsifCfg(const scux_ssif_cfg_t * const p_ssif_param)
                 if ((-1) == sem_wait_ercd)
                 {
                     /* set semaphore error */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
                 else
                 {
                     if (0 != p_ssif_ch->scux_channel)
                     {
-                        retval = EBADF;
+                        retval = EBADF_RBSP;
                     }
                     else
                     {
@@ -2301,13 +2301,13 @@ int_t SCUX_IoctlSetSsifCfg(const scux_ssif_cfg_t * const p_ssif_param)
                 if (osOK != sem_ercd)
                 {
                     /* set semaphore error */
-                    retval = EFAULT;
+                    retval = EFAULT_RBSP;
                 }
             }
         }
         else
         {
-            retval = EPERM;
+            retval = EPERM_RBSP;
         }
     }
 

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif.c
@@ -118,11 +118,11 @@ int_t SSIF_InitialiseOne(const int_t channel, const ssif_channel_cfg_t* const p_
 
     if (NULL == p_cfg_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else if (false == p_cfg_data->enabled)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -190,7 +190,7 @@ int_t SSIF_Initialise(const ssif_channel_cfg_t* const p_cfg_data)
 
     if (NULL == p_cfg_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -275,7 +275,7 @@ int_t SSIF_EnableChannel(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -283,26 +283,26 @@ int_t SSIF_EnableChannel(ssif_info_ch_t* const p_info_ch)
 
         if (ssif_ch >= SSIF_NUM_CHANS)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             /* check channel open flag(duplex) */
-            if ((O_RDWR == p_info_ch->openflag)
+            if ((O_RDWR_RBSP == p_info_ch->openflag)
                 && (false == p_info_ch->is_full_duplex))
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
 
 #if defined(TARGET_RZA1H) /* mbed */
             /* check channel open flag(romdec direct input) */
             if (ESUCCESS == ercd)
             {
-                if ((O_RDONLY != p_info_ch->openflag)
+                if ((O_RDONLY_RBSP != p_info_ch->openflag)
                     && (SSIF_CFG_ENABLE_ROMDEC_DIRECT
                         == p_info_ch->romdec_direct.mode))
                 {
-                    ercd = EINVAL;
+                    ercd = EINVAL_RBSP;
                 }
             }
 
@@ -362,7 +362,7 @@ int_t SSIF_DisableChannel(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -370,7 +370,7 @@ int_t SSIF_DisableChannel(ssif_info_ch_t* const p_info_ch)
 
         if (ssif_ch >= SSIF_NUM_CHANS)
         {
-            ret = EFAULT;
+            ret = EFAULT_RBSP;
         }
         else
         {
@@ -416,7 +416,7 @@ int_t SSIF_DisableChannel(ssif_info_ch_t* const p_info_ch)
 #if(1) /* mbed */
                 p_info_ch->p_aio_tx_next->aio_return = -1;
 #else
-                p_info_ch->p_aio_tx_next->aio_return = ECANCELED;
+                p_info_ch->p_aio_tx_next->aio_return = ECANCELED_RBSP;
 #endif
                 ahf_complete(&p_info_ch->tx_que, p_info_ch->p_aio_tx_next);
                 p_info_ch->p_aio_tx_next = NULL;
@@ -468,7 +468,7 @@ void SSIF_ErrorRecovery(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -476,7 +476,7 @@ void SSIF_ErrorRecovery(ssif_info_ch_t* const p_info_ch)
 
         if (ssif_ch >= SSIF_NUM_CHANS)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -682,7 +682,7 @@ int_t SSIF_IOCTL_ConfigChannel(ssif_info_ch_t* const p_info_ch,
 
     if ((NULL == p_info_ch) || (NULL == p_ch_cfg))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -722,7 +722,7 @@ int_t SSIF_IOCTL_GetStatus(const ssif_info_ch_t* const p_info_ch, uint32_t* cons
 
     if ((NULL == p_info_ch) || (NULL == p_status))
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -830,7 +830,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -843,7 +843,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
 
         if (NULL == p_info_ch->sem_access)
         {
-            ercd = ENOMEM;
+            ercd = ENOMEM_RBSP;
         }
 
         if (ESUCCESS == ercd)
@@ -851,7 +851,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
             ercd = ahf_create(&p_info_ch->tx_que, AHF_LOCKINT);
             if (ESUCCESS != ercd)
             {
-                ercd = ENOMEM;
+                ercd = ENOMEM_RBSP;
             }
         }
 
@@ -860,7 +860,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
             ercd = ahf_create(&p_info_ch->rx_que, AHF_LOCKINT);
             if (ESUCCESS != ercd)
             {
-                ercd = ENOMEM;
+                ercd = ENOMEM_RBSP;
             }
         }
 
@@ -975,7 +975,7 @@ static int_t SSIF_UpdateChannelConfig(ssif_info_ch_t* const p_info_ch,
 
     if ((NULL == p_info_ch) || (NULL == p_ch_cfg))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -1026,7 +1026,7 @@ static int_t SSIF_UpdateChannelConfig(ssif_info_ch_t* const p_info_ch,
                 if ((SSIF_CFG_MULTI_CH_1 == p_info_ch->multi_ch)
                     || (SSIF_CFG_WS_HIGH == p_info_ch->ws_pol))
                 {
-                    ercd = EINVAL;
+                    ercd = EINVAL_RBSP;
                 }
             }
         }
@@ -1082,7 +1082,7 @@ static int_t SSIF_SetCtrlParams(const ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1149,7 +1149,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
 
     if (NULL == p_ch_cfg)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1161,7 +1161,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
             /* do nothing */
             break;
         default:
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
             break;
         }
 
@@ -1179,7 +1179,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1204,7 +1204,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1231,7 +1231,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1246,7 +1246,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1261,7 +1261,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1276,7 +1276,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1291,7 +1291,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1306,7 +1306,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1321,7 +1321,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1336,7 +1336,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1351,7 +1351,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1367,7 +1367,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1398,7 +1398,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1407,7 +1407,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
         if (SSIF_CFG_MULTI_CH_4 < ssicr_chnl)
         /* <-MISRA 13.7 */
         {
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
         }
         else
         {
@@ -1428,7 +1428,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
 
             if (0u == datawd_len)
             {
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
             }
             else
             {
@@ -1437,7 +1437,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
 
                 if (syswd_len < (datawd_len * dw_per_sw))
                 {
-                    ret = EINVAL;
+                    ret = EINVAL_RBSP;
                 }
             }
         }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif_cfg.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif_cfg.c
@@ -616,7 +616,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
 
     if ((NULL == p_ch_cfg) || (NULL == p_clk_div))
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -635,7 +635,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
 
         if (0u == input_clk)
         {
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
         }
 
         if (ESUCCESS == ret)
@@ -658,7 +658,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
 
             if (0u == dot_clk)
             {
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
             }
             else
             {
@@ -668,7 +668,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
                 if (0u != result)
                 {
                     /* cannot create dotclock from input audio clock */
-                    ret = EINVAL;
+                    ret = EINVAL_RBSP;
                 }
                 else
                 {
@@ -716,7 +716,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
                         *p_clk_div = SSIF_CFG_CKDV_BITS_96;
                         break;
                     default:
-                        ret = EINVAL;
+                        ret = EINVAL_RBSP;
                         break;
                     }
                 }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif_dma.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif_dma.c
@@ -116,7 +116,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -125,7 +125,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* allocate DMA Channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY == p_info_ch->openflag)
+            if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 p_info_ch->dma_tx_ch = -1;
             }
@@ -136,7 +136,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 if (EERROR == dma_ret)
                 {
                     p_info_ch->dma_tx_ch = -1;
-                    ercd = ENOMEM;
+                    ercd = ENOMEM_RBSP;
                 }
                 else
                 {
@@ -149,7 +149,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* allocate DMA Channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY == p_info_ch->openflag)
+            if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 p_info_ch->dma_rx_ch = -1;
             }
@@ -160,7 +160,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 if (EERROR == dma_ret)
                 {
                     p_info_ch->dma_rx_ch = -1;
-                    ercd = ENOMEM;
+                    ercd = ENOMEM_RBSP;
                 }
                 else
                 {
@@ -173,7 +173,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_tx_aio = &gb_ssif_dma_tx_end_aiocb[ssif_ch];
                 p_tx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -195,7 +195,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -203,7 +203,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_rx_aio = &gb_ssif_dma_rx_end_aiocb[ssif_ch];
                 p_rx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -224,7 +224,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -232,7 +232,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_txdma_dummy_trparam[ssif_ch].src_addr = (void*)&ssif_tx_dummy_buf[0];
@@ -242,14 +242,14 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -258,7 +258,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_rxdma_dummy_trparam[ssif_ch].src_addr = (void*)&g_ssireg[ssif_ch]->SSIFRDR;
@@ -268,14 +268,14 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -290,24 +290,24 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
             /* enable end interrupt */
             g_ssireg[ssif_ch]->SSIFCR |= SSIF_FCR_BIT_TIE | SSIF_FCR_BIT_RIE;
 
-            if (O_RDWR == p_info_ch->openflag)
+            if (O_RDWR_RBSP == p_info_ch->openflag)
             {
                 /* start write and read DMA at the same time */
                 g_ssireg[ssif_ch]->SSICR  |= SSIF_CR_BIT_TEN | SSIF_CR_BIT_REN;
             }
-            else if (O_WRONLY == p_info_ch->openflag)
+            else if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 /* start write DMA only */
                 g_ssireg[ssif_ch]->SSICR  |= SSIF_CR_BIT_TEN;
             }
-            else if (O_RDONLY == p_info_ch->openflag)
+            else if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 /* start read DMA only */
                 g_ssireg[ssif_ch]->SSICR  |= SSIF_CR_BIT_REN;
             }
             else
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
         }
 
@@ -443,7 +443,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -452,7 +452,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_tx_aio = &gb_ssif_dma_tx_end_aiocb[ssif_ch];
                 p_tx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -474,7 +474,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -482,7 +482,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_rx_aio = &gb_ssif_dma_rx_end_aiocb[ssif_ch];
                 p_rx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -504,7 +504,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -512,7 +512,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_txdma_dummy_trparam[ssif_ch].src_addr = (void*)&ssif_tx_dummy_buf[0];
@@ -522,14 +522,14 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -538,7 +538,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_rxdma_dummy_trparam[ssif_ch].src_addr = (void*)&g_ssireg[ssif_ch]->SSIFRDR;
@@ -548,14 +548,14 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -570,24 +570,24 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
             /* enable end interrupt */
             g_ssireg[ssif_ch]->SSIFCR |= SSIF_FCR_BIT_TIE | SSIF_FCR_BIT_RIE;
 
-            if (O_RDWR == p_info_ch->openflag)
+            if (O_RDWR_RBSP == p_info_ch->openflag)
             {
                 /* start write and read DMA at the same time */
                 g_ssireg[ssif_ch]->SSICR  |= SSIF_CR_BIT_TEN | SSIF_CR_BIT_REN;
             }
-            else if (O_WRONLY == p_info_ch->openflag)
+            else if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 /* start write DMA only */
                 g_ssireg[ssif_ch]->SSICR  |= SSIF_CR_BIT_TEN;
             }
-            else if (O_RDONLY == p_info_ch->openflag)
+            else if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 /* start read DMA only */
                 g_ssireg[ssif_ch]->SSICR  |= SSIF_CR_BIT_REN;
             }
             else
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
         }
     }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif_if.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A1XX/ssif/ssif_if.c
@@ -181,7 +181,7 @@ static void* R_SSIF_InitOne(const int_t channel, const void* const config_data, 
 
     if (NULL == config_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
 #if(1) /* mbed */
     else if ((uint32_t)channel >= SSIF_NUM_CHANS)
@@ -189,7 +189,7 @@ static void* R_SSIF_InitOne(const int_t channel, const void* const config_data, 
     else if (channel >= SSIF_NUM_CHANS)
 #endif
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -242,7 +242,7 @@ static int_t R_SSIF_UnInitOne(const int_t channel, const void* const driver_inst
 
     if (NULL == driver_instance)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
 #if(1) /* mbed */
     else if ((uint32_t)channel >= SSIF_NUM_CHANS)
@@ -250,13 +250,13 @@ static int_t R_SSIF_UnInitOne(const int_t channel, const void* const driver_inst
     else if (channel >= SSIF_NUM_CHANS)
 #endif
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SSIF_DRVSTS_INIT != ch_drv_stat[channel])
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -412,21 +412,21 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
 
     if ((NULL == p_info_drv) || (NULL == p_path_name))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         req_path_len = strlen(p_path_name);
         if (0u == req_path_len)
         {
-            ercd = ENOENT;
+            ercd = ENOENT_RBSP;
         }
 
         if (ESUCCESS == ercd)
         {
             if (SSIF_DRVSTS_INIT != p_info_drv->drv_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
 
@@ -453,7 +453,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
 
     if (NULL == p_info_ch)
     {
-        ercd = ENOENT;
+        ercd = ENOENT_RBSP;
     }
     else
     {
@@ -461,7 +461,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
         {
             if (false == p_info_ch->enabled)
             {
-                ercd = ENOTSUP;
+                ercd = ENOTSUP_RBSP;
             }
         }
 
@@ -469,7 +469,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
         {
             if (SSIF_CHSTS_INIT != p_info_ch->ch_stat)
             {
-                ercd = EBADF;
+                ercd = EBADF_RBSP;
             }
         }
 
@@ -481,7 +481,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
 
             if ((-1) == os_ret)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -499,7 +499,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
             os_ercd = osSemaphoreRelease(p_info_ch->sem_access);
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -539,7 +539,7 @@ static int_t R_SSIF_Close(void* const p_fd, int32_t* const p_errno)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -550,13 +550,13 @@ static int_t R_SSIF_Close(void* const p_fd, int32_t* const p_errno)
 
         if ((-1) == os_ret)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (SSIF_CHSTS_OPEN != p_info_ch->ch_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -575,7 +575,7 @@ static int_t R_SSIF_Close(void* const p_fd, int32_t* const p_errno)
 
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -612,13 +612,13 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SSIF_CHSTS_OPEN != p_info_ch->ch_stat)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -628,7 +628,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
 
             if ((-1) == os_ret)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
 
             if (ESUCCESS == ercd)
@@ -639,7 +639,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -653,7 +653,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -664,7 +664,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
 
                     default:
                     {
-                        ercd = EINVAL;
+                        ercd = EINVAL_RBSP;
                         break;
                     }
                 } /* switch */
@@ -674,7 +674,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
         os_ercd = osSemaphoreRelease(p_info_ch->sem_access);
         if (osOK != os_ercd)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
     }
 
@@ -707,17 +707,17 @@ static int_t R_SSIF_WriteAsync(void* const p_fd, AIOCB* const p_aio, int32_t* co
 
     if ((NULL == p_info_ch) || (NULL == p_aio))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
-        if (((uint32_t)O_RDONLY) == ((uint32_t)p_info_ch->openflag & O_ACCMODE))
+        if (((uint32_t)O_RDONLY_RBSP) == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP))
         {
-            ercd = EACCES;
+            ercd = EACCES_RBSP;
         }
         else if (0u == p_aio->aio_nbytes)
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
         else
         {
@@ -755,23 +755,23 @@ static int_t R_SSIF_ReadAsync(void* const p_fd, AIOCB* const p_aio, int32_t* con
 
     if ((NULL == p_info_ch) || (NULL == p_aio))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
 #if defined(TARGET_RZA1H) /* mbed */
-        if ((O_WRONLY == ((uint32_t)p_info_ch->openflag & O_ACCMODE))
+        if ((O_WRONLY_RBSP == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP))
             || (SSIF_CFG_ENABLE_ROMDEC_DIRECT
                 == p_info_ch->romdec_direct.mode))
 #else /* mbed */
-        if ((O_WRONLY == ((uint32_t)p_info_ch->openflag & O_ACCMODE)))
+        if ((O_WRONLY_RBSP == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP)))
 #endif /* mbed */
         {
-            ercd = EACCES;
+            ercd = EACCES_RBSP;
         }
         else if (0u == p_aio->aio_nbytes)
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
         else
         {
@@ -811,7 +811,7 @@ static int_t R_SSIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const 
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -822,13 +822,13 @@ static int_t R_SSIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const 
 
         if ((-1) == os_ret)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (SSIF_CHSTS_OPEN != p_info_ch->ch_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -839,7 +839,7 @@ static int_t R_SSIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const 
 
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/dma/dma.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/dma/dma.c
@@ -510,13 +510,13 @@ End of function DMA_OpenChannel
 * Return Value :   channel -
 *                     Open channel number.
 *                  error code -
-*                     EMFILE : When looking for a free channel, but a free
+*                     EMFILE_RBSP : When looking for a free channel, but a free
 *                              channel didn't exist.
 ******************************************************************************/
 
 int_t DMA_GetFreeChannel(void)
 {
-    int_t           retval = EFAULT;
+    int_t           retval = EFAULT_RBSP;
     dma_info_ch_t   *dma_info_ch;
     int_t           ch_alloc;
     bool_t          ch_stat_check_flag;
@@ -543,7 +543,7 @@ int_t DMA_GetFreeChannel(void)
                 if (DMA_CH_NUM == ch_alloc)
                 {
                     /* set error return value */
-                    retval = EMFILE;
+                    retval = EMFILE_RBSP;
                     ch_stat_check_flag = true;
                 }
             }
@@ -1000,7 +1000,7 @@ End of function DMA_SetErrCode
 *               Notify error information to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB member.
+*                Note: store error code (EIO_RBSP) to AIOCB member.
 ******************************************************************************/
 
 static void R_DMA_ErrInterruptHandler(void)
@@ -1017,8 +1017,8 @@ static void R_DMA_ErrInterruptHandler(void)
         /* set error infrmation */
         gb_info_drv.p_err_aio->aio_sigevent.sigev_value.sival_int = (int_t)(dstat_er_0_7 | (dstat_er_8_15 << HIGH_COMMON_REG_OFFSET));
 
-        /* set error code (EIO) */
-        gb_info_drv.p_err_aio->aio_return = EIO;
+        /* set error code (EIO_RBSP) */
+        gb_info_drv.p_err_aio->aio_return = EIO_RBSP;
 
         /* call back to the module function which called DMA driver */
         ahf_complete(NULL, gb_info_drv.p_err_aio);
@@ -1042,10 +1042,10 @@ End of function R_DMA_ErrInteruuptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1067,10 +1067,10 @@ End of function R_DMA_End0InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1092,10 +1092,10 @@ End of function R_DMA_End1InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1117,10 +1117,10 @@ End of function R_DMA_End2InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1142,10 +1142,10 @@ End of function R_DMA_End3InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1167,10 +1167,10 @@ End of function R_DMA_End4InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1192,10 +1192,10 @@ End of function R_DMA_End5InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1217,10 +1217,10 @@ End of function R_DMA_End6InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1242,10 +1242,10 @@ End of function R_DMA_End7InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1267,10 +1267,10 @@ End of function R_DMA_End8InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1292,10 +1292,10 @@ End of function R_DMA_End9InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1317,10 +1317,10 @@ End of function R_DMA_End10InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1342,10 +1342,10 @@ End of function R_DMA_End11InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1367,10 +1367,10 @@ End of function R_DMA_End12InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1392,10 +1392,10 @@ End of function R_DMA_End13InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1417,10 +1417,10 @@ End of function R_DMA_End14InterruptHandler
 *               to the module function which called DMA driver.
 * Arguments : None.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1443,10 +1443,10 @@ End of function R_DMA_End15InterruptHandler
 * Arguments : channel -
 *                  Open channel number.
 * Return Value : None.
-*                Note: store error code (EIO) to AIOCB.
+*                Note: store error code (EIO_RBSP) to AIOCB.
 *                  ESUCCESS -
 *                     DMA transfer completed.
-*                  EIO -
+*                  EIO_RBSP -
 *                     DMA transfer don't stopped.
 ******************************************************************************/
 
@@ -1488,8 +1488,8 @@ __INLINE static void R_DMA_EndHandlerProcess(const int_t channel)
             }
             else
             {
-                /* set error code (EIO) */
-                gb_info_drv.info_ch[channel].p_end_aio->aio_return = EIO;
+                /* set error code (EIO_RBSP) */
+                gb_info_drv.info_ch[channel].p_end_aio->aio_return = EIO_RBSP;
             }
         }
         else

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/dma/dma_if.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/dma/dma_if.c
@@ -56,9 +56,9 @@ Private global tables
 *                                  When pointer is NULL, it isn't set error code.
 *                                  error code -
 *                                  OS error num : Registering handler failed.
-*                                  EPERM : Pointer of callback function which called in DMA 
+*                                  EPERM_RBSP : Pointer of callback function which called in DMA 
 *                                          error interrupt handler is NULL.
-*                                  EFAULT : dma_init_param is NULL.
+*                                  EFAULT_RBSP : dma_init_param is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -78,7 +78,7 @@ int_t R_DMA_Init(const dma_drv_init_t * const p_dma_init_param, int32_t * const 
     {
         /* set error return value */
         retval = (EERROR);
-        DMA_SetErrCode(EFAULT, p_errno);
+        DMA_SetErrCode(EFAULT_RBSP, p_errno);
     }
 
     if (ESUCCESS == retval)
@@ -89,7 +89,7 @@ int_t R_DMA_Init(const dma_drv_init_t * const p_dma_init_param, int32_t * const 
         {
             /* set error return value */
             retval = (EERROR);
-            DMA_SetErrCode(EPERM, p_errno);
+            DMA_SetErrCode(EPERM_RBSP, p_errno);
         }
     }
 
@@ -127,9 +127,9 @@ End of function R_DMA_Init
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
 *                           OS error num : Unegistering handler failed.
-*                           EACCES : Driver status isn't DMA_DRV_INIT.
-*                           EBUSY : It has been allocated already in channel.
-*                           EFAULT : Channel status is besides the status definded in dma_stat_ch_t.
+*                           EACCES_RBSP : Driver status isn't DMA_DRV_INIT.
+*                           EBUSY_RBSP : It has been allocated already in channel.
+*                           EFAULT_RBSP : Channel status is besides the status definded in dma_stat_ch_t.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -161,7 +161,7 @@ int_t R_DMA_UnInit(int32_t * const p_errno)
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EACCES, p_errno);
+            DMA_SetErrCode(EACCES_RBSP, p_errno);
         }
         else
         {
@@ -182,11 +182,11 @@ int_t R_DMA_UnInit(int32_t * const p_errno)
                         /* These 2 cases are intentionally combined. */
                         case DMA_CH_OPEN:
                         case DMA_CH_TRANSFER:
-                            DMA_SetErrCode(EBUSY, p_errno);
+                            DMA_SetErrCode(EBUSY_RBSP, p_errno);
                         break;
 
                         default:
-                            DMA_SetErrCode(EFAULT, p_errno);
+                            DMA_SetErrCode(EFAULT_RBSP, p_errno);
                         break;
                     }
                 }
@@ -233,12 +233,12 @@ End of function R_DMA_UnInit
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EINVAL : Value of the ch is outside the range of DMA_ALLOC_CH(-1) <= ch < DMA_CH_NUM.
-*                           EACCES : Driver status isn't DMA_DRV_INIT.
-*                           EBUSY : It has been allocated already in channel.
-*                           EMFILE : When looking for a free channel, but a free channel didn't exist.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t.
+*                           EINVAL_RBSP : Value of the ch is outside the range of DMA_ALLOC_CH(-1) <= ch < DMA_CH_NUM.
+*                           EACCES_RBSP : Driver status isn't DMA_DRV_INIT.
+*                           EBUSY_RBSP : It has been allocated already in channel.
+*                           EMFILE_RBSP : When looking for a free channel, but a free channel didn't exist.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -267,7 +267,7 @@ int_t R_DMA_Alloc(const int_t channel, int32_t * const p_errno)
         if (DMA_DRV_INIT != dma_info_drv->drv_stat)
         {
             /* set error return value */
-            ercd =  EACCES;
+            ercd =  EACCES_RBSP;
         }
         else
         {
@@ -298,7 +298,7 @@ int_t R_DMA_Alloc(const int_t channel, int32_t * const p_errno)
             else
             {
                 /* set error return value */
-                ercd =  EINVAL;
+                ercd =  EINVAL_RBSP;
             }
         }
     }
@@ -330,12 +330,12 @@ End of function R_DMA_Alloc
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EACCES : Driver status isn't DMA_DRV_INIT.
-*                           EBUSY : It has been start DMA transfer in channel.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EACCES_RBSP : Driver status isn't DMA_DRV_INIT.
+*                           EBUSY_RBSP : It has been start DMA transfer in channel.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -382,19 +382,19 @@ int_t R_DMA_Free(const int_t channel, int32_t *const p_errno)
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                             break;
 
                             case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                             break;
 
                             case DMA_CH_TRANSFER:
-                                error_code = EBUSY;
+                                error_code = EBUSY_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                             break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -405,7 +405,7 @@ int_t R_DMA_Free(const int_t channel, int32_t *const p_errno)
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EACCES, p_errno);
+                DMA_SetErrCode(EACCES_RBSP, p_errno);
 
             }
         }
@@ -414,7 +414,7 @@ int_t R_DMA_Free(const int_t channel, int32_t *const p_errno)
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();
@@ -438,12 +438,12 @@ End of function R_DMA_Free
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EBUSY : It has been start DMA transfer in channel.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EPERM : The value in p_ch_setup isn't in the right range.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_ch_setup is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EBUSY_RBSP : It has been start DMA transfer in channel.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EPERM_RBSP : The value in p_ch_setup isn't in the right range.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_ch_setup is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -494,7 +494,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EPERM, p_errno);
+                DMA_SetErrCode(EPERM_RBSP, p_errno);
             }
 
             if (ESUCCESS == retval)
@@ -505,7 +505,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -517,7 +517,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -529,7 +529,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -541,7 +541,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -553,7 +553,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                 {
                     /* set error return value */
                     retval = EERROR;
-                    DMA_SetErrCode(EPERM, p_errno);
+                    DMA_SetErrCode(EPERM_RBSP, p_errno);
                 }
             }
 
@@ -595,7 +595,7 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                         {
                             /* set error return value */
                             retval = EERROR;
-                            DMA_SetErrCode(EPERM, p_errno);
+                            DMA_SetErrCode(EPERM_RBSP, p_errno);
                             check_table_flag = true;
                         }
                         cfg_table_count++;
@@ -624,19 +624,19 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                             break;
 
                             case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                             break;
 
                             case DMA_CH_TRANSFER:
-                                error_code = EBUSY;
+                                error_code = EBUSY_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                             break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -650,14 +650,14 @@ int_t R_DMA_Setup(const int_t channel, const dma_ch_setup_t * const p_ch_setup,
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     return retval;
@@ -679,12 +679,12 @@ End of function R_DMA_SetParam
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EBUSY : It has been start DMA transfer in channel.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EPERM : The value in p_ch_setup isn't in the right range.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EBUSY_RBSP : It has been start DMA transfer in channel.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EPERM_RBSP : The value in p_ch_setup isn't in the right range.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -716,7 +716,7 @@ int_t R_DMA_Start(const int_t channel, const dma_trans_data_t * const p_dma_data
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EPERM, p_errno);
+                DMA_SetErrCode(EPERM_RBSP, p_errno);
             }
 
             if (ESUCCESS == retval)
@@ -742,19 +742,19 @@ int_t R_DMA_Start(const int_t channel, const dma_trans_data_t * const p_dma_data
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                              break;
 
                              case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                              break;
 
                             case DMA_CH_TRANSFER:
-                                error_code = EBUSY;
+                                error_code = EBUSY_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                              break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -766,14 +766,14 @@ int_t R_DMA_Start(const int_t channel, const dma_trans_data_t * const p_dma_data
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();
@@ -797,12 +797,12 @@ End of function R_DMA_Start
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT.
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           EBUSY : It has been set continous DMA transfer.
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EPERM : The value in p_ch_setup isn't in the right range.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT.
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           EBUSY_RBSP : It has been set continous DMA transfer.
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EPERM_RBSP : The value in p_ch_setup isn't in the right range.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_dma_data is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -834,7 +834,7 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
             {
                 /* set error return value */
                 retval = EERROR;
-                DMA_SetErrCode(EPERM, p_errno);
+                DMA_SetErrCode(EPERM_RBSP, p_errno);
             }
 
             if (ESUCCESS == retval)
@@ -855,7 +855,7 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
                         {
                             /* set error return value */
                             retval = EERROR;
-                            DMA_SetErrCode(EBUSY, p_errno);
+                            DMA_SetErrCode(EBUSY_RBSP, p_errno);
                         }
                     }
                     else
@@ -865,15 +865,15 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
                         switch (dma_info_ch->ch_stat)
                         {
                             case DMA_CH_UNINIT:
-                                error_code = ENOTSUP;
+                                error_code = ENOTSUP_RBSP;
                             break;
 
                             case DMA_CH_INIT:
-                                error_code = EBADF;
+                                error_code = EBADF_RBSP;
                             break;
 
                             default:
-                                error_code = EFAULT;
+                                error_code = EFAULT_RBSP;
                             break;
                         }
                         DMA_SetErrCode(error_code, p_errno);
@@ -885,14 +885,14 @@ int_t R_DMA_NextData(const int_t channel, const dma_trans_data_t * const p_dma_d
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();
@@ -916,10 +916,10 @@ End of function R_DMA_NextData
 * @param[in,out] p_errno   :Pointer of error code
 *                           When pointer is NULL, it isn't set error code.
 *                           error code -
-*                           EBADF : Channel status is DMA_CH_INIT or DMA_CH_OPEN. (DMA stopped)
-*                           EINVAL : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
-*                           ENOTSUP : Channel status is DMA_CH_UNINIT.
-*                           EFAULT: Channel status is besides the status definded in dma_stat_ch_t. p_remain is NULL.
+*                           EBADF_RBSP : Channel status is DMA_CH_INIT or DMA_CH_OPEN. (DMA stopped)
+*                           EINVAL_RBSP : Value of the ch is outside the range of (-1) < ch < (DMA_CH_NUM + 1).
+*                           ENOTSUP_RBSP : Channel status is DMA_CH_UNINIT.
+*                           EFAULT_RBSP: Channel status is besides the status definded in dma_stat_ch_t. p_remain is NULL.
 * @retval        ESUCCESS -
 *                  Operation successful.
 *                EERROR -
@@ -961,19 +961,19 @@ int_t R_DMA_Cancel(const int_t channel, uint32_t * const p_remain, int32_t * con
                     switch (dma_info_ch->ch_stat)
                     {
                         case DMA_CH_UNINIT:
-                            error_code = ENOTSUP;
+                            error_code = ENOTSUP_RBSP;
                         break;
 
                         case DMA_CH_INIT:
-                            error_code = EBADF;
+                            error_code = EBADF_RBSP;
                         break;
 
                         case DMA_CH_OPEN:
-                            error_code = EBADF;
+                            error_code = EBADF_RBSP;
                         break;
 
                         default:
-                            error_code = EFAULT;
+                            error_code = EFAULT_RBSP;
                         break;
                     }
                     DMA_SetErrCode(error_code, p_errno);
@@ -984,14 +984,14 @@ int_t R_DMA_Cancel(const int_t channel, uint32_t * const p_remain, int32_t * con
         {
             /* set error return value */
             retval = EERROR;
-            DMA_SetErrCode(EFAULT, p_errno);
+            DMA_SetErrCode(EFAULT_RBSP, p_errno);
         }
     }
     else
     {
         /* set error return value */
         retval = EERROR;
-        DMA_SetErrCode(EINVAL, p_errno);
+        DMA_SetErrCode(EINVAL_RBSP, p_errno);
     }
 
     core_util_critical_section_exit();

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/spdif/spdif.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/spdif/spdif.c
@@ -141,11 +141,11 @@ int_t SPDIF_InitialiseOne(const int_t channel, const spdif_channel_cfg_t* const 
 
     if (NULL == p_cfg_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else if (false == p_cfg_data->enabled)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -304,7 +304,7 @@ int_t SPDIF_EnableChannel(spdif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -330,7 +330,7 @@ int_t SPDIF_EnableChannel(spdif_info_ch_t* const p_info_ch)
         }
 
 
-        if (O_RDONLY != p_info_ch->openflag)
+        if (O_RDONLY_RBSP != p_info_ch->openflag)
         {
             /* ==== Disable interrupt ==== */
             /* ----  Disable interrupt (User data empty) ----  */
@@ -367,7 +367,7 @@ int_t SPDIF_EnableChannel(spdif_info_ch_t* const p_info_ch)
             SPDIF.CTRL.BIT.TUII = 1;
         }
 
-        if (O_WRONLY != p_info_ch->openflag)
+        if (O_WRONLY_RBSP != p_info_ch->openflag)
         {
             /* ==== Status Clear(dummy read) ==== */
             dummy_buf_32 = SPDIF.RUI.LONG;
@@ -414,7 +414,7 @@ int_t SPDIF_DisableChannel(spdif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -502,7 +502,7 @@ void SPDIF_ErrorRecovery_tx(spdif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -510,7 +510,7 @@ void SPDIF_ErrorRecovery_tx(spdif_info_ch_t* const p_info_ch)
         SPDIF.CTRL.LONG &= ~(SPDIF_CTRL_TME | SPDIF_CTRL_TDE);
 
         /* pause DMA transfer */
-        SPDIF_CancelDMA(p_info_ch, O_WRONLY);
+        SPDIF_CancelDMA(p_info_ch, O_WRONLY_RBSP);
 
         /* cancel event to ongoing request */
         if (NULL != p_info_ch->p_aio_tx_curr)
@@ -535,7 +535,7 @@ void SPDIF_ErrorRecovery_tx(spdif_info_ch_t* const p_info_ch)
         }
 
         /* setup/restart DMA transfer */
-        ercd = SPDIF_RestartDMA(p_info_ch, O_WRONLY);
+        ercd = SPDIF_RestartDMA(p_info_ch, O_WRONLY_RBSP);
     }
 
     if (ESUCCESS != ercd)
@@ -552,7 +552,7 @@ void SPDIF_ErrorRecovery_rx(spdif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -560,7 +560,7 @@ void SPDIF_ErrorRecovery_rx(spdif_info_ch_t* const p_info_ch)
         SPDIF.CTRL.LONG &= ~(SPDIF_CTRL_RME | SPDIF_CTRL_RDE);
 
         /* pause DMA transfer */
-        SPDIF_CancelDMA(p_info_ch, O_RDONLY);
+        SPDIF_CancelDMA(p_info_ch, O_RDONLY_RBSP);
 
         /* cancel event to ongoing request */
         if (NULL != p_info_ch->p_aio_rx_curr)
@@ -584,7 +584,7 @@ void SPDIF_ErrorRecovery_rx(spdif_info_ch_t* const p_info_ch)
             p_info_ch->p_aio_rx_next = NULL;
         }
         /* setup/restart DMA transfer */
-        ercd = SPDIF_RestartDMA(p_info_ch, O_RDONLY);
+        ercd = SPDIF_RestartDMA(p_info_ch, O_RDONLY_RBSP);
     }
 
     if (ESUCCESS != ercd)
@@ -694,7 +694,7 @@ int_t SPDIF_IOCTL_ConfigChannel(spdif_info_ch_t* const p_info_ch,
 
     if ((NULL == p_info_ch) || (NULL == p_ch_cfg))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -741,7 +741,7 @@ int_t SPDIF_IOCTL_SetChannelStatus(spdif_info_ch_t* const p_info_ch,
 
     if ((NULL == p_info_ch) || (NULL == p_channel_status))
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -771,7 +771,7 @@ int_t SPDIF_IOCTL_GetChannelStatus(spdif_info_ch_t* const p_info_ch,
 
     if ((NULL == p_info_ch) || (NULL == p_channel_status))
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -800,7 +800,7 @@ int_t SPDIF_IOCTL_SetTransAudioBit(spdif_info_ch_t* const p_info_ch,
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -814,7 +814,7 @@ int_t SPDIF_IOCTL_SetTransAudioBit(spdif_info_ch_t* const p_info_ch,
             /* do nothing */
             break;
         default:
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
             break;
         }
 
@@ -846,7 +846,7 @@ int_t SPDIF_IOCTL_SetRecvAudioBit(spdif_info_ch_t* const p_info_ch,
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -860,7 +860,7 @@ int_t SPDIF_IOCTL_SetRecvAudioBit(spdif_info_ch_t* const p_info_ch,
             /* do nothing */
             break;
         default:
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
             break;
         }
 
@@ -897,7 +897,7 @@ static int_t SPDIF_InitChannel(spdif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -906,7 +906,7 @@ static int_t SPDIF_InitChannel(spdif_info_ch_t* const p_info_ch)
 
         if (NULL == p_info_ch->sem_access)
         {
-            ercd = ENOMEM;
+            ercd = ENOMEM_RBSP;
         }
 
         if (ESUCCESS == ercd)
@@ -914,7 +914,7 @@ static int_t SPDIF_InitChannel(spdif_info_ch_t* const p_info_ch)
             ercd = ahf_create(&p_info_ch->tx_que, AHF_LOCKINT);
             if (ESUCCESS != ercd)
             {
-                ercd = ENOMEM;
+                ercd = ENOMEM_RBSP;
             }
         }
 
@@ -923,7 +923,7 @@ static int_t SPDIF_InitChannel(spdif_info_ch_t* const p_info_ch)
             ercd = ahf_create(&p_info_ch->rx_que, AHF_LOCKINT);
             if (ESUCCESS != ercd)
             {
-                ercd = ENOMEM;
+                ercd = ENOMEM_RBSP;
             }
         }
 
@@ -1046,7 +1046,7 @@ static int_t SPDIF_SetCtrlParams(const spdif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1086,7 +1086,7 @@ static int_t SPDIF_CheckChannelCfg(const spdif_channel_cfg_t* const p_ch_cfg)
 
     if (NULL == p_ch_cfg)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1098,7 +1098,7 @@ static int_t SPDIF_CheckChannelCfg(const spdif_channel_cfg_t* const p_ch_cfg)
             /* do nothing */
             break;
         default:
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
             break;
         }
 
@@ -1114,7 +1114,7 @@ static int_t SPDIF_CheckChannelCfg(const spdif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1131,7 +1131,7 @@ static int_t SPDIF_CheckChannelCfg(const spdif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/spdif/spdif_dma.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/spdif/spdif_dma.c
@@ -88,14 +88,14 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         /* allocate DMA Channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY == p_info_ch->openflag)
+            if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 p_info_ch->dma_tx_ch = -1;
             }
@@ -106,7 +106,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
                 if (EERROR == dma_ret)
                 {
                     p_info_ch->dma_tx_ch = -1;
-                    ercd = ENOMEM;
+                    ercd = ENOMEM_RBSP;
                 }
                 else
                 {
@@ -119,7 +119,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
         /* allocate DMA Channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY == p_info_ch->openflag)
+            if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 p_info_ch->dma_rx_ch = -1;
             }
@@ -130,7 +130,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
                 if (EERROR == dma_ret)
                 {
                     p_info_ch->dma_rx_ch = -1;
-                    ercd = ENOMEM;
+                    ercd = ENOMEM_RBSP;
                 }
                 else
                 {
@@ -143,7 +143,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
         /* setup DMA channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_tx_aio = &gb_spdif_dma_tx_end_aiocb;
                 p_tx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -161,7 +161,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_Setup(p_info_ch->dma_tx_ch, &dma_ch_setup, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -169,7 +169,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
         /* setup DMA channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_rx_aio = &gb_spdif_dma_rx_end_aiocb;
                 p_rx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -187,7 +187,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_Setup(p_info_ch->dma_rx_ch, &dma_ch_setup, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -195,7 +195,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_spdif_txdma_dummy_trparam.src_addr = (void*)&spdif_tx_dummy_buf[0];
@@ -205,14 +205,14 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_tx_ch, &gb_spdif_txdma_dummy_trparam, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_tx_ch, &gb_spdif_txdma_dummy_trparam, &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -221,7 +221,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_spdif_rxdma_dummy_trparam.src_addr = (void*)&SPDIF.RDAD.LONG;
@@ -231,14 +231,14 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_rx_ch, &gb_spdif_rxdma_dummy_trparam, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_rx_ch, &gb_spdif_rxdma_dummy_trparam, &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -249,20 +249,20 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
         {
             /* clear status and enable error interrupt */
             /* enable end interrupt */
-            if (O_RDWR == p_info_ch->openflag)
+            if (O_RDWR_RBSP == p_info_ch->openflag)
             {
                 /* start write and read DMA at the same time */
                 SPDIF.STAT.LONG &= ~(SPDIF_STAT_READ_ONLY | SPDIF_STAT_UBU | SPDIF_STAT_CSE | SPDIF_STAT_ABU |
                                      SPDIF_STAT_UBO | SPDIF_STAT_CE | SPDIF_STAT_PARE | SPDIF_STAT_PREE | SPDIF_STAT_ABO);
                 SPDIF.CTRL.LONG |= (SPDIF_CTRL_TME | SPDIF_CTRL_TDE | SPDIF_CTRL_RME | SPDIF_CTRL_RDE);
             }
-            else if (O_WRONLY == p_info_ch->openflag)
+            else if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 /* start write DMA only */
                 SPDIF.STAT.LONG &= ~(SPDIF_STAT_READ_ONLY | SPDIF_STAT_UBU | SPDIF_STAT_CSE | SPDIF_STAT_ABU);
                 SPDIF.CTRL.LONG |= (SPDIF_CTRL_TME | SPDIF_CTRL_TDE);
             }
-            else if (O_RDONLY == p_info_ch->openflag)
+            else if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 /* start read DMA only */
                 SPDIF.STAT.LONG &= ~(SPDIF_STAT_READ_ONLY | SPDIF_STAT_UBO | SPDIF_STAT_CE | SPDIF_STAT_PARE | SPDIF_STAT_PREE | SPDIF_STAT_ABO);
@@ -270,7 +270,7 @@ int_t SPDIF_InitDMA(spdif_info_ch_t* const p_info_ch)
             }
             else
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
         }
 
@@ -405,14 +405,14 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         /* setup DMA channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != openflag)
+            if (O_RDONLY_RBSP != openflag)
             {
                 AIOCB* const p_tx_aio = &gb_spdif_dma_tx_end_aiocb;
                 p_tx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -430,7 +430,7 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
                 dma_ret = R_DMA_Setup(p_info_ch->dma_tx_ch, &dma_ch_setup, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -438,7 +438,7 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
         /* setup DMA channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != openflag)
+            if (O_WRONLY_RBSP != openflag)
             {
                 AIOCB* const p_rx_aio = &gb_spdif_dma_rx_end_aiocb;
                 p_rx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -456,7 +456,7 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
                 dma_ret = R_DMA_Setup(p_info_ch->dma_rx_ch, &dma_ch_setup, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -464,7 +464,7 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
         /* start DMA dummy transfer for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != openflag)
+            if (O_RDONLY_RBSP != openflag)
             {
                 /* setup short dummy transfer */
                 gb_spdif_txdma_dummy_trparam.src_addr = (void*)&spdif_tx_dummy_buf[0];
@@ -474,14 +474,14 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_tx_ch, &gb_spdif_txdma_dummy_trparam, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_tx_ch, &gb_spdif_txdma_dummy_trparam, &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -490,7 +490,7 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
         /* start DMA dummy transfer for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != openflag)
+            if (O_WRONLY_RBSP != openflag)
             {
                 /* setup short dummy transfer */
                 gb_spdif_rxdma_dummy_trparam.src_addr = (void*)&SPDIF.RDAD.LONG;
@@ -500,14 +500,14 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_rx_ch, &gb_spdif_rxdma_dummy_trparam, &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_rx_ch, &gb_spdif_rxdma_dummy_trparam, &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -518,20 +518,20 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
         {
             /* clear status and enable error interrupt */
             /* enable end interrupt */
-            if (O_RDWR == openflag)
+            if (O_RDWR_RBSP == openflag)
             {
                 /* start write and read DMA at the same time */
                 SPDIF.STAT.LONG &= ~(SPDIF_STAT_UBU | SPDIF_STAT_CSE | SPDIF_STAT_ABU);
                 SPDIF.STAT.LONG &= ~(SPDIF_STAT_UBO | SPDIF_STAT_CE | SPDIF_STAT_PARE | SPDIF_STAT_PREE | SPDIF_STAT_ABO);
                 SPDIF.CTRL.LONG |= (SPDIF_CTRL_TME | SPDIF_CTRL_TDE | SPDIF_CTRL_RME | SPDIF_CTRL_RDE);
             }
-            else if (O_WRONLY == openflag)
+            else if (O_WRONLY_RBSP == openflag)
             {
                 /* start write DMA only */
                 SPDIF.STAT.LONG &= ~(SPDIF_STAT_UBU | SPDIF_STAT_CSE | SPDIF_STAT_ABU);
                 SPDIF.CTRL.LONG |= (SPDIF_CTRL_TME | SPDIF_CTRL_TDE);
             }
-            else if (O_RDONLY == openflag)
+            else if (O_RDONLY_RBSP == openflag)
             {
                 /* start read DMA only */
                 SPDIF.STAT.LONG &= ~(SPDIF_STAT_UBO | SPDIF_STAT_CE | SPDIF_STAT_PARE | SPDIF_STAT_PREE | SPDIF_STAT_ABO);
@@ -539,7 +539,7 @@ int_t SPDIF_RestartDMA(spdif_info_ch_t* const p_info_ch, int_t openflag)
             }
             else
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
         }
     }
@@ -567,7 +567,7 @@ void SPDIF_CancelDMA(const spdif_info_ch_t* const p_info_ch, int_t openflag)
     }
     else
     {
-        if (O_RDONLY != openflag) {
+        if (O_RDONLY_RBSP != openflag) {
             if (-1 != p_info_ch->dma_tx_ch)
             {
                 uint32_t remain;
@@ -579,7 +579,7 @@ void SPDIF_CancelDMA(const spdif_info_ch_t* const p_info_ch, int_t openflag)
             }
         }
 
-        if (O_WRONLY != openflag) {
+        if (O_WRONLY_RBSP != openflag) {
             if (-1 != p_info_ch->dma_rx_ch)
             {
                 uint32_t remain;

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/spdif/spdif_if.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/spdif/spdif_if.c
@@ -168,7 +168,7 @@ static void* R_SPDIF_InitOne(const int_t channel, const void* const config_data,
 
     if (NULL == config_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
 #if(1) /* mbed */
     else if ((uint32_t)channel >= SPDIF_NUM_CHANS)
@@ -176,7 +176,7 @@ static void* R_SPDIF_InitOne(const int_t channel, const void* const config_data,
     else if (channel >= SPDIF_NUM_CHANS)
 #endif
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -229,7 +229,7 @@ static int_t R_SPDIF_UnInitOne(const int_t channel, const void* const driver_ins
 
     if (NULL == driver_instance)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
 #if(1) /* mbed */
     else if ((uint32_t)channel >= SPDIF_NUM_CHANS)
@@ -237,13 +237,13 @@ static int_t R_SPDIF_UnInitOne(const int_t channel, const void* const driver_ins
     else if (channel >= SPDIF_NUM_CHANS)
 #endif
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SPDIF_DRVSTS_INIT != ch_drv_stat[channel])
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -387,21 +387,21 @@ static int_t R_SPDIF_Open(void* const p_driver_instance, const char_t* const p_p
 
     if ((NULL == p_info_drv) || (NULL == p_path_name))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         req_path_len = strlen(p_path_name);
         if (0u == req_path_len)
         {
-            ercd = ENOENT;
+            ercd = ENOENT_RBSP;
         }
 
         if (ESUCCESS == ercd)
         {
             if (SPDIF_DRVSTS_INIT != p_info_drv->drv_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
 
@@ -424,7 +424,7 @@ static int_t R_SPDIF_Open(void* const p_driver_instance, const char_t* const p_p
 
     if (NULL == p_info_ch)
     {
-        ercd = ENOENT;
+        ercd = ENOENT_RBSP;
     }
     else
     {
@@ -432,7 +432,7 @@ static int_t R_SPDIF_Open(void* const p_driver_instance, const char_t* const p_p
         {
             if (false == p_info_ch->enabled)
             {
-                ercd = ENOTSUP;
+                ercd = ENOTSUP_RBSP;
             }
         }
 
@@ -440,7 +440,7 @@ static int_t R_SPDIF_Open(void* const p_driver_instance, const char_t* const p_p
         {
             if (SPDIF_CHSTS_INIT != p_info_ch->ch_stat)
             {
-                ercd = EBADF;
+                ercd = EBADF_RBSP;
             }
         }
 
@@ -452,7 +452,7 @@ static int_t R_SPDIF_Open(void* const p_driver_instance, const char_t* const p_p
 
             if ((-1) == os_ret)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -470,7 +470,7 @@ static int_t R_SPDIF_Open(void* const p_driver_instance, const char_t* const p_p
             os_ercd = osSemaphoreRelease(p_info_ch->sem_access);
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -510,7 +510,7 @@ static int_t R_SPDIF_Close(void* const p_fd, int32_t* const p_errno)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -521,13 +521,13 @@ static int_t R_SPDIF_Close(void* const p_fd, int32_t* const p_errno)
 
         if ((-1) == os_ret)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (SPDIF_CHSTS_OPEN != p_info_ch->ch_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -546,7 +546,7 @@ static int_t R_SPDIF_Close(void* const p_fd, int32_t* const p_errno)
 
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -583,13 +583,13 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SPDIF_CHSTS_OPEN != p_info_ch->ch_stat)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -599,7 +599,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
 
             if ((-1) == os_ret)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
 
             if (ESUCCESS == ercd)
@@ -610,7 +610,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -624,7 +624,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -637,7 +637,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -650,7 +650,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -663,7 +663,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -674,7 +674,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
 
                     default:
                     {
-                        ercd = EINVAL;
+                        ercd = EINVAL_RBSP;
                         break;
                     }
                 } /* switch */
@@ -684,7 +684,7 @@ static int_t R_SPDIF_Ioctl(void* const p_fd, const int_t request, void* const p_
         os_ercd = osSemaphoreRelease(p_info_ch->sem_access);
         if (osOK != os_ercd)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
     }
 
@@ -717,17 +717,17 @@ static int_t R_SPDIF_WriteAsync(void* const p_fd, AIOCB* const p_aio, int32_t* c
 
     if ((NULL == p_info_ch) || (NULL == p_aio))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
-        if (((uint32_t)O_RDONLY) == ((uint32_t)p_info_ch->openflag & O_ACCMODE))
+        if (((uint32_t)O_RDONLY_RBSP) == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP))
         {
-            ercd = EACCES;
+            ercd = EACCES_RBSP;
         }
         else if ((0u == p_aio->aio_nbytes) && (p_aio->aio_buf == NULL))
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
         else
         {
@@ -772,17 +772,17 @@ static int_t R_SPDIF_ReadAsync(void* const p_fd, AIOCB* const p_aio, int32_t* co
 
     if ((NULL == p_info_ch) || (NULL == p_aio))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
-        if ((O_WRONLY == ((uint32_t)p_info_ch->openflag & O_ACCMODE)))
+        if ((O_WRONLY_RBSP == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP)))
         {
-            ercd = EACCES;
+            ercd = EACCES_RBSP;
         }
         else if ((0u == p_aio->aio_nbytes) && (p_aio->aio_buf == NULL))
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
         else
         {
@@ -829,7 +829,7 @@ static int_t R_SPDIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -840,13 +840,13 @@ static int_t R_SPDIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const
 
         if ((-1) == os_ret)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (SPDIF_CHSTS_OPEN != p_info_ch->ch_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -857,7 +857,7 @@ static int_t R_SPDIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const
 
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif.c
@@ -112,11 +112,11 @@ int_t SSIF_InitialiseOne(const int_t channel, const ssif_channel_cfg_t* const p_
 
     if (NULL == p_cfg_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else if (false == p_cfg_data->enabled)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -184,7 +184,7 @@ int_t SSIF_Initialise(const ssif_channel_cfg_t* const p_cfg_data)
 
     if (NULL == p_cfg_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -269,7 +269,7 @@ int_t SSIF_EnableChannel(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -277,26 +277,26 @@ int_t SSIF_EnableChannel(ssif_info_ch_t* const p_info_ch)
 
         if (ssif_ch >= SSIF_NUM_CHANS)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             /* check channel open flag(duplex) */
-            if ((O_RDWR == p_info_ch->openflag)
+            if ((O_RDWR_RBSP == p_info_ch->openflag)
                 && (false == p_info_ch->is_full_duplex))
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
 
 #if defined(TARGET_RZA1H) /* mbed */
             /* check channel open flag(romdec direct input) */
             if (ESUCCESS == ercd)
             {
-                if ((O_RDONLY != p_info_ch->openflag)
+                if ((O_RDONLY_RBSP != p_info_ch->openflag)
                     && (SSIF_CFG_ENABLE_ROMDEC_DIRECT
                         == p_info_ch->romdec_direct.mode))
                 {
-                    ercd = EINVAL;
+                    ercd = EINVAL_RBSP;
                 }
             }
 
@@ -359,7 +359,7 @@ int_t SSIF_DisableChannel(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -367,7 +367,7 @@ int_t SSIF_DisableChannel(ssif_info_ch_t* const p_info_ch)
 
         if (ssif_ch >= SSIF_NUM_CHANS)
         {
-            ret = EFAULT;
+            ret = EFAULT_RBSP;
         }
         else
         {
@@ -468,7 +468,7 @@ void SSIF_ErrorRecovery(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -476,7 +476,7 @@ void SSIF_ErrorRecovery(ssif_info_ch_t* const p_info_ch)
 
         if (ssif_ch >= SSIF_NUM_CHANS)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -682,7 +682,7 @@ int_t SSIF_IOCTL_ConfigChannel(ssif_info_ch_t* const p_info_ch,
 
     if ((NULL == p_info_ch) || (NULL == p_ch_cfg))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -722,7 +722,7 @@ int_t SSIF_IOCTL_GetStatus(const ssif_info_ch_t* const p_info_ch, uint32_t* cons
 
     if ((NULL == p_info_ch) || (NULL == p_status))
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -822,7 +822,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -835,7 +835,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
 
         if (NULL == p_info_ch->sem_access)
         {
-            ercd = ENOMEM;
+            ercd = ENOMEM_RBSP;
         }
 
         if (ESUCCESS == ercd)
@@ -843,7 +843,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
             ercd = ahf_create(&p_info_ch->tx_que, AHF_LOCKINT);
             if (ESUCCESS != ercd)
             {
-                ercd = ENOMEM;
+                ercd = ENOMEM_RBSP;
             }
         }
 
@@ -852,7 +852,7 @@ static int_t SSIF_InitChannel(ssif_info_ch_t* const p_info_ch)
             ercd = ahf_create(&p_info_ch->rx_que, AHF_LOCKINT);
             if (ESUCCESS != ercd)
             {
-                ercd = ENOMEM;
+                ercd = ENOMEM_RBSP;
             }
         }
 
@@ -967,7 +967,7 @@ static int_t SSIF_UpdateChannelConfig(ssif_info_ch_t* const p_info_ch,
 
     if ((NULL == p_info_ch) || (NULL == p_ch_cfg))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -1020,7 +1020,7 @@ static int_t SSIF_UpdateChannelConfig(ssif_info_ch_t* const p_info_ch,
                 if ((SSIF_CFG_MULTI_CH_1 == p_info_ch->multi_ch)
                     || (SSIF_CFG_WS_HIGH == p_info_ch->ws_pol))
                 {
-                    ercd = EINVAL;
+                    ercd = EINVAL_RBSP;
                 }
             }
         }
@@ -1064,7 +1064,7 @@ static int_t SSIF_SetCtrlParams(const ssif_info_ch_t* const p_info_ch)
     uint32_t ssif_ch;
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1121,7 +1121,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
 
     if (NULL == p_ch_cfg)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1133,7 +1133,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
             /* do nothing */
             break;
         default:
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
             break;
         }
 
@@ -1151,7 +1151,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1176,7 +1176,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1203,7 +1203,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1218,7 +1218,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1233,7 +1233,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1248,7 +1248,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1263,7 +1263,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1278,7 +1278,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1293,7 +1293,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1308,7 +1308,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1323,7 +1323,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1339,7 +1339,7 @@ static int_t SSIF_CheckChannelCfg(const ssif_channel_cfg_t* const p_ch_cfg)
                 /* do nothing */
                 break;
             default:
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
                 break;
             }
         }
@@ -1370,7 +1370,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -1379,7 +1379,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
         if (SSIF_CFG_MULTI_CH_4 < ssicr_chnl)
         /* <-MISRA 13.7 */
         {
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
         }
         else
         {
@@ -1400,7 +1400,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
 
             if (0u == datawd_len)
             {
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
             }
             else
             {
@@ -1409,7 +1409,7 @@ static int_t SSIF_CheckWordSize(const ssif_info_ch_t* const p_info_ch)
 
                 if (syswd_len < (datawd_len * dw_per_sw))
                 {
-                    ret = EINVAL;
+                    ret = EINVAL_RBSP;
                 }
             }
         }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif_cfg.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif_cfg.c
@@ -217,7 +217,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
 
     if ((NULL == p_ch_cfg) || (NULL == p_clk_div))
     {
-        ret = EFAULT;
+        ret = EFAULT_RBSP;
     }
     else
     {
@@ -236,7 +236,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
 
         if (0u == input_clk)
         {
-            ret = EINVAL;
+            ret = EINVAL_RBSP;
         }
 
         if (ESUCCESS == ret)
@@ -259,7 +259,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
 
             if (0u == dot_clk)
             {
-                ret = EINVAL;
+                ret = EINVAL_RBSP;
             }
             else
             {
@@ -269,7 +269,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
                 if (0u != result)
                 {
                     /* cannot create dotclock from input audio clock */
-                    ret = EINVAL;
+                    ret = EINVAL_RBSP;
                 }
                 else
                 {
@@ -317,7 +317,7 @@ int_t R_SSIF_Userdef_SetClockDiv(const ssif_channel_cfg_t* const p_ch_cfg, ssif_
                         *p_clk_div = SSIF_CFG_CKDV_BITS_96;
                         break;
                     default:
-                        ret = EINVAL;
+                        ret = EINVAL_RBSP;
                         break;
                     }
                 }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif_dma.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif_dma.c
@@ -108,7 +108,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -117,7 +117,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* allocate DMA Channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY == p_info_ch->openflag)
+            if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 p_info_ch->dma_tx_ch = -1;
             }
@@ -128,7 +128,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 if (EERROR == dma_ret)
                 {
                     p_info_ch->dma_tx_ch = -1;
-                    ercd = ENOMEM;
+                    ercd = ENOMEM_RBSP;
                 }
                 else
                 {
@@ -141,7 +141,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* allocate DMA Channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY == p_info_ch->openflag)
+            if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 p_info_ch->dma_rx_ch = -1;
             }
@@ -152,7 +152,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 if (EERROR == dma_ret)
                 {
                     p_info_ch->dma_rx_ch = -1;
-                    ercd = ENOMEM;
+                    ercd = ENOMEM_RBSP;
                 }
                 else
                 {
@@ -165,7 +165,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_tx_aio = &gb_ssif_dma_tx_end_aiocb[ssif_ch];
                 p_tx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -187,7 +187,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -195,7 +195,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_rx_aio = &gb_ssif_dma_rx_end_aiocb[ssif_ch];
                 p_rx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -216,7 +216,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -224,7 +224,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_txdma_dummy_trparam[ssif_ch].src_addr = (void*)&ssif_tx_dummy_buf[0];
@@ -234,14 +234,14 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -250,7 +250,7 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_rxdma_dummy_trparam[ssif_ch].src_addr = (void*)&g_ssireg[ssif_ch]->SSIFRDR.LONG;
@@ -260,14 +260,14 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -282,24 +282,24 @@ int_t SSIF_InitDMA(ssif_info_ch_t* const p_info_ch)
             /* enable end interrupt */
             g_ssireg[ssif_ch]->SSIFCR.LONG |= SSIF_FCR_BIT_TIE | SSIF_FCR_BIT_RIE;
 
-            if (O_RDWR == p_info_ch->openflag)
+            if (O_RDWR_RBSP == p_info_ch->openflag)
             {
                 /* start write and read DMA at the same time */
                 g_ssireg[ssif_ch]->SSICR.LONG  |= SSIF_CR_BIT_TEN | SSIF_CR_BIT_REN;
             }
-            else if (O_WRONLY == p_info_ch->openflag)
+            else if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 /* start write DMA only */
                 g_ssireg[ssif_ch]->SSICR.LONG  |= SSIF_CR_BIT_TEN;
             }
-            else if (O_RDONLY == p_info_ch->openflag)
+            else if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 /* start read DMA only */
                 g_ssireg[ssif_ch]->SSICR.LONG  |= SSIF_CR_BIT_REN;
             }
             else
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
         }
 
@@ -435,7 +435,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -444,7 +444,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_tx_aio = &gb_ssif_dma_tx_end_aiocb[ssif_ch];
                 p_tx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -466,7 +466,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -474,7 +474,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* setup DMA channel for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 AIOCB* const p_rx_aio = &gb_ssif_dma_rx_end_aiocb[ssif_ch];
                 p_rx_aio->aio_sigevent.sigev_notify = SIGEV_THREAD;
@@ -496,7 +496,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
 
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
             }
         }
@@ -504,7 +504,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for write(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_RDONLY != p_info_ch->openflag)
+            if (O_RDONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_txdma_dummy_trparam[ssif_ch].src_addr = (void*)&ssif_tx_dummy_buf[0];
@@ -514,14 +514,14 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_tx_ch, &gb_ssif_txdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -530,7 +530,7 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
         /* start DMA dummy transfer for read(if necessary) */
         if (ESUCCESS == ercd)
         {
-            if (O_WRONLY != p_info_ch->openflag)
+            if (O_WRONLY_RBSP != p_info_ch->openflag)
             {
                 /* setup short dummy transfer */
                 gb_ssif_rxdma_dummy_trparam[ssif_ch].src_addr = (void*)&g_ssireg[ssif_ch]->SSIFRDR.LONG;
@@ -540,14 +540,14 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
                 dma_ret = R_DMA_NextData(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                 if (EERROR == dma_ret)
                 {
-                    ercd = EFAULT;
+                    ercd = EFAULT_RBSP;
                 }
                 else
                 {
                     dma_ret = R_DMA_Start(p_info_ch->dma_rx_ch, &gb_ssif_rxdma_dummy_trparam[ssif_ch], &dma_ercd);
                     if (EERROR == dma_ret)
                     {
-                        ercd = EFAULT;
+                        ercd = EFAULT_RBSP;
                     }
                 }
             }
@@ -562,24 +562,24 @@ int_t SSIF_RestartDMA(ssif_info_ch_t* const p_info_ch)
             /* enable end interrupt */
             g_ssireg[ssif_ch]->SSIFCR.LONG |= SSIF_FCR_BIT_TIE | SSIF_FCR_BIT_RIE;
 
-            if (O_RDWR == p_info_ch->openflag)
+            if (O_RDWR_RBSP == p_info_ch->openflag)
             {
                 /* start write and read DMA at the same time */
                 g_ssireg[ssif_ch]->SSICR.LONG  |= SSIF_CR_BIT_TEN | SSIF_CR_BIT_REN;
             }
-            else if (O_WRONLY == p_info_ch->openflag)
+            else if (O_WRONLY_RBSP == p_info_ch->openflag)
             {
                 /* start write DMA only */
                 g_ssireg[ssif_ch]->SSICR.LONG  |= SSIF_CR_BIT_TEN;
             }
-            else if (O_RDONLY == p_info_ch->openflag)
+            else if (O_RDONLY_RBSP == p_info_ch->openflag)
             {
                 /* start read DMA only */
                 g_ssireg[ssif_ch]->SSICR.LONG  |= SSIF_CR_BIT_REN;
             }
             else
             {
-                ercd = EINVAL;
+                ercd = EINVAL_RBSP;
             }
         }
     }

--- a/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif_if.c
+++ b/R_BSP/RenesasBSP/drv_src/TARGET_RZ_A2XX/ssif/ssif_if.c
@@ -181,7 +181,7 @@ static void* R_SSIF_InitOne(const int_t channel, const void* const config_data, 
 
     if (NULL == config_data)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
 #if(1) /* mbed */
     else if ((uint32_t)channel >= SSIF_NUM_CHANS)
@@ -189,7 +189,7 @@ static void* R_SSIF_InitOne(const int_t channel, const void* const config_data, 
     else if (channel >= SSIF_NUM_CHANS)
 #endif
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -242,7 +242,7 @@ static int_t R_SSIF_UnInitOne(const int_t channel, const void* const driver_inst
 
     if (NULL == driver_instance)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
 #if(1) /* mbed */
     else if ((uint32_t)channel >= SSIF_NUM_CHANS)
@@ -250,13 +250,13 @@ static int_t R_SSIF_UnInitOne(const int_t channel, const void* const driver_inst
     else if (channel >= SSIF_NUM_CHANS)
 #endif
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SSIF_DRVSTS_INIT != ch_drv_stat[channel])
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -408,21 +408,21 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
 
     if ((NULL == p_info_drv) || (NULL == p_path_name))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         req_path_len = strlen(p_path_name);
         if (0u == req_path_len)
         {
-            ercd = ENOENT;
+            ercd = ENOENT_RBSP;
         }
 
         if (ESUCCESS == ercd)
         {
             if (SSIF_DRVSTS_INIT != p_info_drv->drv_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
 
@@ -449,7 +449,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
 
     if (NULL == p_info_ch)
     {
-        ercd = ENOENT;
+        ercd = ENOENT_RBSP;
     }
     else
     {
@@ -457,7 +457,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
         {
             if (false == p_info_ch->enabled)
             {
-                ercd = ENOTSUP;
+                ercd = ENOTSUP_RBSP;
             }
         }
 
@@ -465,7 +465,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
         {
             if (SSIF_CHSTS_INIT != p_info_ch->ch_stat)
             {
-                ercd = EBADF;
+                ercd = EBADF_RBSP;
             }
         }
 
@@ -477,7 +477,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
 
             if ((-1) == os_ret)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -495,7 +495,7 @@ static int_t R_SSIF_Open(void* const p_driver_instance, const char_t* const p_pa
             os_ercd = osSemaphoreRelease(p_info_ch->sem_access);
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -535,7 +535,7 @@ static int_t R_SSIF_Close(void* const p_fd, int32_t* const p_errno)
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -546,13 +546,13 @@ static int_t R_SSIF_Close(void* const p_fd, int32_t* const p_errno)
 
         if ((-1) == os_ret)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (SSIF_CHSTS_OPEN != p_info_ch->ch_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -571,7 +571,7 @@ static int_t R_SSIF_Close(void* const p_fd, int32_t* const p_errno)
 
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }
@@ -608,13 +608,13 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
         if (SSIF_CHSTS_OPEN != p_info_ch->ch_stat)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
@@ -624,7 +624,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
 
             if ((-1) == os_ret)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
 
             if (ESUCCESS == ercd)
@@ -635,7 +635,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -649,7 +649,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
                     {
                         if (NULL == p_buf)
                         {
-                            ercd = EFAULT;
+                            ercd = EFAULT_RBSP;
                         }
                         else
                         {
@@ -660,7 +660,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
 
                     default:
                     {
-                        ercd = EINVAL;
+                        ercd = EINVAL_RBSP;
                         break;
                     }
                 } /* switch */
@@ -670,7 +670,7 @@ static int_t R_SSIF_Ioctl(void* const p_fd, const int_t request, void* const p_b
         os_ercd = osSemaphoreRelease(p_info_ch->sem_access);
         if (osOK != os_ercd)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
     }
 
@@ -703,17 +703,17 @@ static int_t R_SSIF_WriteAsync(void* const p_fd, AIOCB* const p_aio, int32_t* co
 
     if ((NULL == p_info_ch) || (NULL == p_aio))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
-        if (((uint32_t)O_RDONLY) == ((uint32_t)p_info_ch->openflag & O_ACCMODE))
+        if (((uint32_t)O_RDONLY_RBSP) == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP))
         {
-            ercd = EACCES;
+            ercd = EACCES_RBSP;
         }
         else if (0u == p_aio->aio_nbytes)
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
         else
         {
@@ -751,23 +751,23 @@ static int_t R_SSIF_ReadAsync(void* const p_fd, AIOCB* const p_aio, int32_t* con
 
     if ((NULL == p_info_ch) || (NULL == p_aio))
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
 #if defined(TARGET_RZA1H) /* mbed */
-        if ((O_WRONLY == ((uint32_t)p_info_ch->openflag & O_ACCMODE))
+        if ((O_WRONLY_RBSP == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP))
             || (SSIF_CFG_ENABLE_ROMDEC_DIRECT
                 == p_info_ch->romdec_direct.mode))
 #else /* mbed */
-        if ((O_WRONLY == ((uint32_t)p_info_ch->openflag & O_ACCMODE)))
+        if ((O_WRONLY_RBSP == ((uint32_t)p_info_ch->openflag & O_ACCMODE_RBSP)))
 #endif /* mbed */
         {
-            ercd = EACCES;
+            ercd = EACCES_RBSP;
         }
         else if (0u == p_aio->aio_nbytes)
         {
-            ercd = EINVAL;
+            ercd = EINVAL_RBSP;
         }
         else
         {
@@ -807,7 +807,7 @@ static int_t R_SSIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const 
 
     if (NULL == p_info_ch)
     {
-        ercd = EFAULT;
+        ercd = EFAULT_RBSP;
     }
     else
     {
@@ -818,13 +818,13 @@ static int_t R_SSIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const 
 
         if ((-1) == os_ret)
         {
-            ercd = EFAULT;
+            ercd = EFAULT_RBSP;
         }
         else
         {
             if (SSIF_CHSTS_OPEN != p_info_ch->ch_stat)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
             else
             {
@@ -835,7 +835,7 @@ static int_t R_SSIF_Cancel(void* const p_fd, AIOCB* const p_aio, int32_t* const 
 
             if (osOK != os_ercd)
             {
-                ercd = EFAULT;
+                ercd = EFAULT_RBSP;
             }
         }
     }

--- a/R_BSP/RenesasBSP/drv_src/ioif/aioif.c
+++ b/R_BSP/RenesasBSP/drv_src/ioif/aioif.c
@@ -89,7 +89,7 @@ int32_t ahf_create (AHF_S * const ahf, const uint32_t f)
 
     if (ahf == NULL)
     {
-        return EFAULT;
+        return EFAULT_RBSP;
     }
 
     ahf->head = NULL;
@@ -110,7 +110,7 @@ int32_t ahf_create (AHF_S * const ahf, const uint32_t f)
 #endif/*__GNUC__*/
         if ( NULL == p_mutex_def )
         {
-            return ENOMEM;
+            return ENOMEM_RBSP;
         }
 #if defined (__GNUC__)
         /* disable all irq */
@@ -132,7 +132,7 @@ int32_t ahf_create (AHF_S * const ahf, const uint32_t f)
             /* enable all irq */
             core_util_critical_section_exit();
 #endif/*__GNUC__*/
-            return ENOMEM;
+            return ENOMEM_RBSP;
         }
         p_mutex_def->cb_mem = p_mutex_data;
         ahf->p_cmtx = p_mutex_def;
@@ -149,7 +149,7 @@ int32_t ahf_create (AHF_S * const ahf, const uint32_t f)
             /* enable all irq */
             core_util_critical_section_exit();
 #endif/*__GNUC__*/
-            return ENOMEM;
+            return ENOMEM_RBSP;
         }
     }
 
@@ -308,7 +308,7 @@ void ahf_cancelall (AHF_S * const ahf)
     while (cur != NULL)
     {
         next = cur->pNext;
-        cur->aio_return = ECANCELED;
+        cur->aio_return = ECANCELED_RBSP;
         ahf_complete (ahf, cur);
         cur = next;
     }
@@ -402,11 +402,11 @@ Return value:   0 on success.   negative error code on error.
 int32_t ahf_cancel (AHF_S * const ahf, struct aiocb * const aio)
 {
     struct aiocb *cur;
-    int32_t rv = EINVAL;
+    int32_t rv = EINVAL_RBSP;
 
     if (ahf == NULL)
     {
-        return EFAULT;
+        return EFAULT_RBSP;
     }
 
     /* If aio is NULL, must cancel all. */
@@ -448,7 +448,7 @@ int32_t ahf_cancel (AHF_S * const ahf, struct aiocb * const aio)
                 ahf->tail = cur->pPrev;
             }
 
-            cur->aio_return = ECANCELED;
+            cur->aio_return = ECANCELED_RBSP;
             ahf_complete (ahf, aio);
             rv = 0;
         }

--- a/R_BSP/common/R_BSP_Aio.cpp
+++ b/R_BSP/common/R_BSP_Aio.cpp
@@ -112,9 +112,9 @@ int32_t R_BSP_Aio::read(void * const p_data, uint32_t data_size, const rbsp_data
     rbsp_read_write_a_func_t p_func = (rbsp_read_write_a_func_t)p_ctl->p_async_func;
 
     if ((p_data_conf == NULL) || (p_data == NULL)) {
-        wk_errno = ENOSPC;
+        wk_errno = ENOSPC_RBSP;
     } else if (p_ctl->p_sem_ctl->wait(osWaitForever) == -1) {
-        wk_errno = EIO;
+        wk_errno = EIO_RBSP;
     } else {
         p_rbsp_aio = (AIOCB *)p_ctl->p_aio_top + p_ctl->index;
         p_sival    = p_ctl->p_sival_top + p_ctl->index;

--- a/R_BSP/common/R_BSP_SerialFamily.cpp
+++ b/R_BSP/common/R_BSP_SerialFamily.cpp
@@ -52,11 +52,11 @@ bool R_BSP_SerialFamily::init_channel(RBSP_MBED_FNS * function_list, int channel
     int_t   flags;
 
     if ((max_write_num > 0) && (max_read_num > 0)) {
-        flags = O_RDWR;
+        flags = O_RDWR_RBSP;
     } else if (max_write_num > 0) {
-        flags = O_WRONLY;
+        flags = O_WRONLY_RBSP;
     } else if (max_read_num > 0) {
-        flags = O_RDONLY;
+        flags = O_RDONLY_RBSP;
     } else {
         flags = 0;
     }


### PR DESCRIPTION
It causes the build error by using the latest Mbed OS environment and IAR compiler. Because mbed_retarget.h file' behavior was changed by recent updating.
Thus, to pass IAR compiler using the latest Mbed OS, I revised the definition of Posix related macro at R_BSP dir.